### PR TITLE
Support for Second-order Cones

### DIFF
--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -4,11 +4,13 @@ mod ball2;
 mod cartesian_product;
 mod no_constraints;
 mod rectangle;
+mod soc;
 
 pub use ball2::Ball2;
 pub use cartesian_product::CartesianProduct;
 pub use no_constraints::NoConstraints;
 pub use rectangle::Rectangle;
+pub use soc::SecondOrderCone;
 
 /// A set which can be used as a constraint
 ///

--- a/src/constraints/soc.rs
+++ b/src/constraints/soc.rs
@@ -5,13 +5,21 @@ use crate::matrix_operations;
 /// A second-order cone (SOC)
 ///
 /// A set of the form `{ (x, t) : ||x|| <= a*t}`, where `a` is a positive
-/// scalar
+/// scalar.
+///
+/// Projections on the second-order cone are computed as in H.H. Bauschke's
+/// 1996 doctoral dissertation: Projection Algorithms and Monotone Operators
+/// (p. 40, Theorem 3.3.6).
 pub struct SecondOrderCone {
     alpha: f64,
 }
 
 impl SecondOrderCone {
-    /// Construct a new rectangle with given `xmin` and `xmax`
+    /// Construct a new instance of SecondOrderCone with parameter `alpha`
+    ///
+    /// ### Panics
+    ///
+    /// The method panics if the given parameter `alpha` is nonpositive.
     pub fn new(alpha: f64) -> SecondOrderCone {
         assert!(alpha > 0.0); // alpha must be positive
         SecondOrderCone { alpha }
@@ -19,6 +27,11 @@ impl SecondOrderCone {
 }
 
 impl Constraint for SecondOrderCone {
+    /// Project on the second-order cone (updates the given vector/slice)
+    ///
+    /// ### Panics
+    ///
+    /// The methods panics is the length of `x` is less than 2.
     fn project(&self, x: &mut [f64]) {
         // x = (z, r)
         let n = x.len();

--- a/src/constraints/soc.rs
+++ b/src/constraints/soc.rs
@@ -1,0 +1,22 @@
+use super::Constraint;
+
+///
+/// A second-order cone (SOC)
+///
+/// A set of the form `{ (x, t) : ||x|| <= a*t}`, where `a` is a positive
+/// scalar
+pub struct SecondOrderCone {
+    alpha: f64,
+}
+
+impl SecondOrderCone {
+    /// Construct a new rectangle with given `xmin` and `xmax`
+    pub fn new(alpha: f64) -> SecondOrderCone {
+        assert!(alpha > 0.0); // alpha must be positive
+        SecondOrderCone { alpha }
+    }
+}
+
+impl Constraint for SecondOrderCone {
+    fn project(&self, _x: &mut [f64]) {}
+}

--- a/src/constraints/soc.rs
+++ b/src/constraints/soc.rs
@@ -1,4 +1,5 @@
 use super::Constraint;
+use crate::matrix_operations;
 
 ///
 /// A second-order cone (SOC)
@@ -18,5 +19,18 @@ impl SecondOrderCone {
 }
 
 impl Constraint for SecondOrderCone {
-    fn project(&self, _x: &mut [f64]) {}
+    fn project(&self, x: &mut [f64]) {
+        // x = (z, r)
+        let n = x.len();
+        let z = &x[..n - 1];
+        let r = x[n - 1];
+        let norm_z = matrix_operations::norm2(z);
+        if self.alpha * norm_z <= -r {
+            x.iter_mut().for_each(|v| *v = 0.0);
+        } else if norm_z > self.alpha * r {
+            let beta = (self.alpha * norm_z + r) / (self.alpha.powi(2) + 1.0);
+            x[..n - 1].iter_mut().for_each(|v| *v *= self.alpha * beta);
+            x[n - 1] = beta;
+        }
+    }
 }

--- a/src/constraints/soc.rs
+++ b/src/constraints/soc.rs
@@ -4,7 +4,7 @@ use crate::matrix_operations;
 ///
 /// A second-order cone (SOC)
 ///
-/// A set of the form `{ (x, t) : ||x|| <= a*t}`, where `a` is a positive
+/// A set of the form `{ x=(y, t) : ||t|| <= a*t}`, where `a` is a positive
 /// scalar.
 ///
 /// Projections on the second-order cone are computed as in H.H. Bauschke's
@@ -16,6 +16,13 @@ pub struct SecondOrderCone {
 
 impl SecondOrderCone {
     /// Construct a new instance of SecondOrderCone with parameter `alpha`
+    ///
+    /// A second-order cone with parameter alpha is the set `C = {x=(y, t): ||y|| <= alpha*t}`,
+    /// where `alpha` is a positive parameter,
+    /// and projections are computed according to Theorem 3.3.6 in H.H. Bauschke's 1996 doctoral
+    /// dissertation:
+    /// [Projection Algorithms and Monotone Operators](http://summit.sfu.ca/system/files/iritems1/7015/b18025766.pdf)
+    /// (page 40).
     ///
     /// ### Panics
     ///
@@ -29,9 +36,15 @@ impl SecondOrderCone {
 impl Constraint for SecondOrderCone {
     /// Project on the second-order cone (updates the given vector/slice)
     ///
+    /// ### Arguments
+    ///
+    /// - `x`: (in) vector to be projected on the current instance of a second-order
+    ///   cone, (out) projection on the second-order cone
+    ///
     /// ### Panics
     ///
     /// The methods panics is the length of `x` is less than 2.
+    ///
     fn project(&self, x: &mut [f64]) {
         // x = (z, r)
         let n = x.len();

--- a/src/constraints/soc.rs
+++ b/src/constraints/soc.rs
@@ -22,6 +22,7 @@ impl Constraint for SecondOrderCone {
     fn project(&self, x: &mut [f64]) {
         // x = (z, r)
         let n = x.len();
+        assert!(n >= 2, "x must be of dimension at least 2");
         let z = &x[..n - 1];
         let r = x[n - 1];
         let norm_z = matrix_operations::norm2(z);
@@ -29,7 +30,9 @@ impl Constraint for SecondOrderCone {
             x.iter_mut().for_each(|v| *v = 0.0);
         } else if norm_z > self.alpha * r {
             let beta = (self.alpha * norm_z + r) / (self.alpha.powi(2) + 1.0);
-            x[..n - 1].iter_mut().for_each(|v| *v *= self.alpha * beta);
+            x[..n - 1]
+                .iter_mut()
+                .for_each(|v| *v *= self.alpha * beta / norm_z);
             x[n - 1] = beta;
         }
     }

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -336,7 +336,7 @@ fn t_second_order_cone_short_vector() {
     soc.project(&mut _x);
 }
 
-
+#[test]
 fn t_cartesian_product_dimension() {
     let data: Vec<Vec<f64>> = vec![vec![0.0, 0.0], vec![1.0, 1.0]];
     let finite_set = FiniteSet::new(data);

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -125,7 +125,7 @@ fn t_no_constraints() {
 
 #[test]
 #[should_panic]
-fn cartesian_product_constraints_incoherent_indices() {
+fn t_cartesian_product_constraints_incoherent_indices() {
     let ball1 = Ball2::new(None, 1.0);
     let ball2 = Ball2::new(None, 0.5);
     let mut cart_prod = CartesianProduct::new();
@@ -135,7 +135,7 @@ fn cartesian_product_constraints_incoherent_indices() {
 
 #[test]
 #[should_panic]
-fn cartesian_product_constraints_wrong_vector_dim() {
+fn t_cartesian_product_constraints_wrong_vector_dim() {
     let ball1 = Ball2::new(None, 1.0);
     let ball2 = Ball2::new(None, 0.5);
     let mut cart_prod = CartesianProduct::new();
@@ -146,7 +146,7 @@ fn cartesian_product_constraints_wrong_vector_dim() {
 }
 
 #[test]
-fn cartesian_product_constraints() {
+fn t_cartesian_product_constraints() {
     let radius1 = 1.0;
     let radius2 = 0.5;
     let idx1 = 3;
@@ -165,7 +165,7 @@ fn cartesian_product_constraints() {
 }
 
 #[test]
-fn cartesian_product_ball_and_rectangle() {
+fn t_cartesian_product_ball_and_rectangle() {
     /* Rectangle 1 */
     let xmin1 = vec![-1.0; 3];
     let xmax1 = vec![1.0; 3];
@@ -208,4 +208,65 @@ fn cartesian_product_ball_and_rectangle() {
         1e-10,
         "wrong projection on rectangle 2",
     );
+}
+
+#[test]
+fn t_second_order_cone_case_i() {
+    let soc = SecondOrderCone::new(1.0);
+    let mut x = vec![1.0, 1.0, 1.42];
+    let x_copy = x.clone();
+    soc.project(&mut x);
+    unit_test_utils::assert_nearly_equal_array(&x, &x_copy, 1e-10, 1e-12, "x has been modified");
+}
+
+#[test]
+fn t_second_order_cone_case_ii() {
+    let alpha = 0.5;
+    let soc = SecondOrderCone::new(alpha);
+    let mut x = vec![1.0, 1.0, -0.71];
+    soc.project(&mut x);
+    let expected = vec![0.0; 3];
+    unit_test_utils::assert_nearly_equal_array(
+        &x,
+        &expected,
+        1e-10,
+        1e-12,
+        "wrong result (should be zero)",
+    );
+}
+
+#[test]
+fn t_second_order_cone_case_iii() {
+    let alpha = 1.5;
+    let soc = SecondOrderCone::new(alpha);
+    let mut x = vec![1.0, 1.0, 0.1];
+    soc.project(&mut x);
+    // make sure the new `x` is in the cone
+    let norm_z = crate::matrix_operations::norm2(&x[..=1]);
+    assert!(norm_z <= alpha * x[2]);
+    // in fact the projection should be on the boundary of the cone
+    assert!((norm_z - alpha * x[2]).abs() <= 1e-7);
+}
+
+#[test]
+#[should_panic]
+fn t_second_order_cone_illegal_alpha_i() {
+    let alpha = 0.0;
+    let _soc = SecondOrderCone::new(alpha);
+}
+
+#[test]
+#[should_panic]
+fn t_second_order_cone_illegal_alpha_ii() {
+    let alpha = -1.0;
+    let _soc = SecondOrderCone::new(alpha);
+}
+
+#[test]
+#[should_panic]
+fn t_second_order_cone_short_vector() {
+    let alpha = 1.0;
+    let soc = SecondOrderCone::new(alpha);
+    let mut _x = vec![1.0];
+    soc.project(&mut _x);
 }


### PR DESCRIPTION
See issue #67.

- [x] Implementation of structure `SecondOrderCone`
- [x] Unit tests (see `src/constraints/tests.rs`)
- [x] Rust documentation

Ready to be merged