### PR TITLE
Re-introducing Python tests

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -32,9 +32,7 @@ main() {
     cd opengen
     export PYTHONPATH=.
     python -W ignore test/test_constraints.py -v
-    
-    # --- temporarily commented out:
-    # python -W ignore test/test.py -v
+    python -W ignore test/test.py -v
 }
 
 main

--- a/open-codegen/opengen/builder/optimizer_builder.py
+++ b/open-codegen/opengen/builder/optimizer_builder.py
@@ -90,7 +90,7 @@ class OpEnOptimizerBuilder:
         Cargo build command (possibly, with --release)
 
         """
-        command = ['cargo', 'build']
+        command = ['cargo', 'build', '-q']
         if self.__build_config.build_mode.lower() == 'release':
             command.append('--release')
 
@@ -506,7 +506,7 @@ class OpEnOptimizerBuilder:
             Exception: if there some parameters have wrong, inadmissible or incompatible values
 
         """
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(level=logging.INFO)
         self.__initialize()                      # initialize default value (if not provided)
         self.__check_user_provided_parameters()  # check the provided parameters
         self.__prepare_target_project()          # create folders; init cargo project

--- a/open-codegen/opengen/tcp/optimizer_tcp_manager.py
+++ b/open-codegen/opengen/tcp/optimizer_tcp_manager.py
@@ -49,7 +49,7 @@ class OptimizerTcpManager:
         logging.info("Starting TCP/IP server at %s:%d (in a detached thread)",
                      optimizer_details['tcp']['ip'],
                      optimizer_details['tcp']['port'])
-        command = ['cargo', 'run']
+        command = ['cargo', 'run', '-q']
         if optimizer_details['build']['build_mode'] == 'release':
             command.append('--release')
         tcp_iface_directory = os.path.join(self.__optimizer_path, "tcp_iface")

--- a/open-codegen/opengen/templates/optimizer_cinterface.rs.template
+++ b/open-codegen/opengen/templates/optimizer_cinterface.rs.template
@@ -139,7 +139,6 @@ pub extern "C" fn {{meta.optimizer_name|lower}}_solve(
     // Invoke `solve`
     let status = solve(params,&mut instance.cache, u, &y0_option, &c0_option);
 
-    println!("status = {:#?}", status);
     // Check solution status and cast it as `{{meta.optimizer_name}}SolverStatus`
     match status {
         Ok(status) => {{meta.optimizer_name}}SolverStatus {

--- a/open-codegen/opengen/templates/optimizer_cinterface.rs.template
+++ b/open-codegen/opengen/templates/optimizer_cinterface.rs.template
@@ -139,6 +139,7 @@ pub extern "C" fn {{meta.optimizer_name|lower}}_solve(
     // Invoke `solve`
     let status = solve(params,&mut instance.cache, u, &y0_option, &c0_option);
 
+    println!("status = {:#?}", status);
     // Check solution status and cast it as `{{meta.optimizer_name}}SolverStatus`
     match status {
         Ok(status) => {{meta.optimizer_name}}SolverStatus {
@@ -155,7 +156,7 @@ pub extern "C" fn {{meta.optimizer_name|lower}}_solve(
             delta_y_norm_over_c: status.delta_y_norm_over_c() as c_double,
             f2_norm: status.f2_norm() as c_double,
             lagrange: match status.lagrange_multipliers() {
-                Some(y) => {
+                Some({% if problem.dim_constraints_aug_lagrangian() == 0 %}_{% endif %}y) => {
                 {%- if problem.dim_constraints_aug_lagrangian() > 0 %}
                     let mut y_array : [f64; {{meta.optimizer_name|upper}}_N1] = Default::default();
                     y_array.copy_from_slice(&y);

--- a/open-codegen/opengen/templates/tcp_server.rs.template
+++ b/open-codegen/opengen/templates/tcp_server.rs.template
@@ -139,6 +139,16 @@ fn execution_handler(
     }
 
     // ----------------------------------------------------
+    // Check lagrange multipliers
+    // ----------------------------------------------------
+    if let Some(y0) = &execution_parameter.initial_lagrange_multipliers {
+        if y0.len() != {{meta.optimizer_name|upper}}_N1 {
+            write_error_message(stream, 1700, "wrong dimension of Langrange multipliers");
+            return;
+        }
+    }
+
+    // ----------------------------------------------------
     // Run solver
     // ----------------------------------------------------
     let parameter = &execution_parameter.parameter;

--- a/open-codegen/opengen/templates/tcp_server.rs.template
+++ b/open-codegen/opengen/templates/tcp_server.rs.template
@@ -92,7 +92,7 @@ fn return_solution_to_client(
     solution: &[f64],
     stream: &mut std::net::TcpStream,
 ) {
-    let empty_vec = [0.0];
+    let empty_vec : [f64; 0] = Default::default();
     let solution: OptimizerSolution = OptimizerSolution {
         exit_status: format!("{:?}", status.exit_status()),
         num_outer_iterations: status.num_outer_iterations(),

--- a/open-codegen/opengen/test/test.py
+++ b/open-codegen/opengen/test/test.py
@@ -225,6 +225,8 @@ class RustBuildTestCase(unittest.TestCase):
         response = mng.call(p=[2.0, 10.0])
         self.assertEqual("Converged", response["exit_status"])
 
+        mng.kill()
+
     # def test_link_2_c_libs(self):
     #     u = cs.SX.sym("u", 5)
     #     p = cs.SX.sym("p", 2)
@@ -321,6 +323,6 @@ class RustBuildTestCase(unittest.TestCase):
     #         exit(rc)
     #
 
-    
+
 if __name__ == '__main__':
     unittest.main()

--- a/open-codegen/opengen/test/test.py
+++ b/open-codegen/opengen/test/test.py
@@ -2,7 +2,7 @@ import unittest
 import casadi.casadi as cs
 import opengen as og
 import subprocess
-
+import json
 
 class RustBuildTestCase(unittest.TestCase):
 
@@ -60,230 +60,292 @@ class RustBuildTestCase(unittest.TestCase):
         with self.assertRaises(Exception) as __context:
             og.config.SolverConfiguration().with_max_inner_iterations()
 
-    def test_build_incompatible_dim_(self):
-        u = cs.SX.sym("u", 5)
-        p = cs.SX.sym("p", 2)
-        phi = og.functions.rosenbrock(u, p)
-        c = cs.vertcat(u[0], u[1],  u[2] - u[3])
+    def test_rust_build_only_f1(self):
+        u = cs.MX.sym("u", 5)  # decision variable (nu = 5)
+        p = cs.MX.sym("p", 2)  # parameter (np = 2)
+        f1 = cs.vertcat(1.5 * u[0] - u[1], u[2] - u[3])
+        set_c = og.constraints.BallInf([0.0, 0.1], 0.001)
+        set_y = og.constraints.BallInf(None, 1e12)
+        phi = og.functions.rosenbrock(u, p)  # cost function
+        bounds = og.constraints.Ball2(None, 1.5)  # ball centered at origin
         problem = og.builder.Problem(u, p, phi) \
-            .with_penalty_constraints(c)
-        build_config = og.config.BuildConfiguration()
+            .with_aug_lagrangian_constraints(f1, set_c, set_y) \
+            .with_constraints(bounds)
+        build_config = og.config.BuildConfiguration() \
+            .with_build_directory(RustBuildTestCase.TEST_DIR) \
+            .with_build_mode("debug") \
+            .with_tcp_interface_config()
         solver_config = og.config.SolverConfiguration() \
-            .with_initial_penalty_weights([1.0, 2.0]) # should have dim = 3
-        with self.assertRaises(Exception) as __context:
-            og.builder.OpEnOptimizerBuilder(problem,
-                                            build_configuration=build_config,
-                                            solver_configuration=solver_config) \
-                .with_generate_not_build_flag(True).build()
+            .with_lfbgs_memory(15) \
+            .with_tolerance(1e-4) \
+            .with_initial_tolerance(1e-4) \
+            .with_delta_tolerance(1e-4) \
+            .with_initial_penalty(15.0) \
+            .with_penalty_weight_update_factor(10.0) \
+            .with_max_inner_iterations(155) \
+            .with_max_duration_micros(1e8) \
+            .with_max_outer_iterations(50) \
+            .with_sufficient_decrease_coefficient(0.05) \
+            .with_cbfgs_parameters(1.5, 1e-10, 1e-12)
+        og.builder.OpEnOptimizerBuilder(problem,
+                                        build_configuration=build_config,
+                                        solver_configuration=solver_config) \
+            .build()
+        mng = og.tcp.OptimizerTcpManager(RustBuildTestCase.TEST_DIR + '/open_optimizer')
+        mng.start()
+        pong = mng.ping()  # check if the server is alive
+        print(pong)
+        response = mng.call(p=[2.0, 10.0])
+        mng.kill()
+        self.assertEqual("Converged", response["exit_status"])
+        print(json.dumps(response, indent=4, sort_keys=False))
 
-    def test_rust_build_with_penalty(self):
+    def test_rust_build_only_f2(self):
         u = cs.SX.sym("u", 15)
         p = cs.SX.sym("p", 2)
         phi = og.functions.rosenbrock(u, p)
-        c = cs.vertcat(1.5 * u[0] - u[1], u[2] - u[3])
+        f2 = cs.vertcat(1.5 * u[0] - u[1], u[2] - u[3])
         bounds = og.constraints.Ball2(None, 1.5)
         problem = og.builder.Problem(u, p, phi) \
-            .with_penalty_constraints(c) \
+            .with_penalty_constraints(f2) \
             .with_constraints(bounds)
         build_config = og.config.BuildConfiguration() \
             .with_build_directory(RustBuildTestCase.TEST_DIR) \
             .with_build_mode("debug")
         og.builder.OpEnOptimizerBuilder(problem, build_configuration=build_config) \
-            .with_generate_not_build_flag(False).build()
+            .build()
 
-    def test_rust_build_without_penalty(self):
+    def test_rust_build_only_f1_and_f2(self):
         u = cs.SX.sym("u", 15)
         p = cs.SX.sym("p", 2)
         phi = og.functions.rosenbrock(u, p)
-        bounds = og.constraints.Ball2(None, 1.5)
-        problem = og.builder.Problem(u, p, phi)   \
-            .with_penalty_constraints(None)       \
+        f1 = cs.vertcat(1.5 * u[0] - u[1], u[2] - u[3])
+        f2 = cs.vertcat(u[4] - 1.0, u[5], cs.sin(u[6]), cs.cos(u[7]+u[8]))
+        set_c = og.constraints.Ball2([0.1, 0.1], 1)
+        set_y = og.constraints.BallInf(None, 1e12)
+        bounds = og.constraints.BallInf(None, 1.5)
+        problem = og.builder.Problem(u, p, phi) \
+            .with_aug_lagrangian_constraints(f1, set_c, set_y) \
+            .with_penalty_constraints(f2) \
             .with_constraints(bounds)
-        build_config = og.config.BuildConfiguration()          \
-            .with_build_directory(RustBuildTestCase.TEST_DIR)  \
+        build_config = og.config.BuildConfiguration() \
+            .with_build_directory(RustBuildTestCase.TEST_DIR) \
             .with_build_mode("debug")
         og.builder.OpEnOptimizerBuilder(problem, build_configuration=build_config) \
-            .with_generate_not_build_flag(False).build()
+            .build()
 
-    def test_rust_build_with_tcp_server(self):
-        u = cs.SX.sym("u", 5)
+    def test_rust_build_only_no_f1_no_f2(self):
+        u = cs.SX.sym("u", 15)
         p = cs.SX.sym("p", 2)
         phi = og.functions.rosenbrock(u, p)
-        bounds = og.constraints.Ball2(None, 1.5)
+        f1 = cs.vertcat(1.5 * u[0] - u[1], u[2] - u[3])
+        f2 = cs.vertcat(u[4] - 1.0, u[5], cs.sin(u[6]), cs.cos(u[7]+u[8]))
+        set_c = og.constraints.Ball2(None, 1)
+        set_y = og.constraints.BallInf(None, 1e12)
+        bounds = og.constraints.BallInf(None, 1.5)
         problem = og.builder.Problem(u, p, phi) \
-            .with_penalty_constraints(None)     \
+            .with_aug_lagrangian_constraints(f1, set_c, set_y) \
+            .with_penalty_constraints(f2) \
             .with_constraints(bounds)
-        build_config = og.config.BuildConfiguration()         \
+        build_config = og.config.BuildConfiguration() \
             .with_build_directory(RustBuildTestCase.TEST_DIR) \
-            .with_build_mode("debug")                         \
-            .with_tcp_interface_config()
-        meta = og.config.OptimizerMeta()                      \
-            .with_optimizer_name("tcp_enabled_optimizer")
-        builder = og.builder.OpEnOptimizerBuilder(problem,
-                                                  metadata=meta,
-                                                  build_configuration=build_config) \
-            .with_generate_not_build_flag(False).with_verbosity_level(1)
-        builder.build()
+            .with_build_mode("debug")
+        og.builder.OpEnOptimizerBuilder(problem, build_configuration=build_config) \
+            .build()
 
-    def test_fully_featured_release_mode(self):
-        u = cs.SX.sym("u", 5)
-        p = cs.SX.sym("p", 2)
-        phi = og.functions.rosenbrock(u, p)
-        c = cs.vertcat(1.5*u[0] - u[1], u[2] - u[3])
-        xmin = [-2.0, -2.0, -2.0, -2.0, -2.0]
-        xmax = [ 2.0,  2.0,  2.0,  2.0,  2.0]
-        bounds = og.constraints.Rectangle(xmin, xmax)
-        problem = og.builder.Problem(u, p, phi) \
-            .with_penalty_constraints(c)        \
-            .with_constraints(bounds)
-        meta = og.config.OptimizerMeta()                \
-            .with_version("0.0.0")                      \
-            .with_authors(["P. Sopasakis", "E. Fresk"]) \
-            .with_licence("CC4.0-By")                   \
-            .with_optimizer_name("the_optimizer")
-        build_config = og.config.BuildConfiguration()          \
-            .with_rebuild(False)                               \
-            .with_build_mode("debug")                          \
-            .with_build_directory(RustBuildTestCase.TEST_DIR)  \
-            .with_build_c_bindings()                           \
-            .with_tcp_interface_config()
-        solver_config = og.config.SolverConfiguration()   \
-            .with_lfbgs_memory(15)                        \
-            .with_tolerance(1e-5)                         \
-            .with_max_inner_iterations(155)               \
-            .with_delta_tolerance(1e-4)             \
-            .with_max_outer_iterations(15)                \
-            .with_penalty_weight_update_factor(8.0)       \
-            .with_initial_penalty_weights([20.0, 5.0]).with_cbfgs_parameters(1.0, 1e-8, 1e-9)
-        builder = og.builder.OpEnOptimizerBuilder(problem,
-                                                  metadata=meta,
-                                                  build_configuration=build_config,
-                                                  solver_configuration=solver_config) \
-            .with_generate_not_build_flag(False).with_verbosity_level(0)
-        builder.build()
-
-    def test_link_2_c_libs(self):
-        u = cs.SX.sym("u", 5)
-        p = cs.SX.sym("p", 2)
-        phi = og.functions.rosenbrock(u, p)
-        c = cs.vertcat(1.5*u[0] - u[1], u[2] - u[3])
-        xmin = [-2.0, -2.0, -2.0, -2.0, -2.0]
-        xmax = [ 2.0,  2.0,  2.0,  2.0,  2.0]
-        bounds = og.constraints.Rectangle(xmin, xmax)
-        problem = og.builder.Problem(u, p, phi) \
-            .with_penalty_constraints(c)        \
-            .with_constraints(bounds)
-        meta1 = og.config.OptimizerMeta()               \
-            .with_version("0.0.0")                      \
-            .with_authors(["P. Sopasakis", "E. Fresk"]) \
-            .with_licence("CC4.0-By")                   \
-            .with_optimizer_name("the_optimizer1")
-        meta2 = og.config.OptimizerMeta()               \
-            .with_version("0.0.0")                      \
-            .with_authors(["P. Sopasakis", "E. Fresk"]) \
-            .with_licence("CC4.0-By")                   \
-            .with_optimizer_name("the_optimizer2")
-        build_config = og.config.BuildConfiguration()          \
-            .with_rebuild(False)                               \
-            .with_build_mode("debug")                          \
-            .with_build_directory(RustBuildTestCase.TEST_DIR)  \
-            .with_build_c_bindings()
-        solver_config = og.config.SolverConfiguration()   \
-            .with_lfbgs_memory(15)                        \
-            .with_tolerance(1e-5)                         \
-            .with_max_inner_iterations(155)               \
-            .with_delta_tolerance(1e-4)             \
-            .with_max_outer_iterations(15)                \
-            .with_penalty_weight_update_factor(8.0)       \
-            .with_initial_penalty_weights([20.0, 5.0])
-
-        builder1 = og.builder.OpEnOptimizerBuilder(problem,
-                                                  metadata=meta1,
-                                                  build_configuration=build_config,
-                                                  solver_configuration=solver_config) \
-            .with_generate_not_build_flag(False).with_verbosity_level(0)
-        builder1.build()
-
-        builder2 = og.builder.OpEnOptimizerBuilder(problem,
-                                                  metadata=meta2,
-                                                  build_configuration=build_config,
-                                                  solver_configuration=solver_config) \
-            .with_generate_not_build_flag(False).with_verbosity_level(0)
-        builder2.build()
-
-        p = subprocess.Popen(["gcc",
-            "test/test_2_solvers.c",
-            "-I" + RustBuildTestCase.TEST_DIR + "/the_optimizer1",
-            "-I" + RustBuildTestCase.TEST_DIR + "/the_optimizer2",
-            "-pthread",
-            RustBuildTestCase.TEST_DIR + "/the_optimizer1/target/debug/libthe_optimizer1.a",
-            RustBuildTestCase.TEST_DIR + "/the_optimizer2/target/debug/libthe_optimizer2.a",
-            "-lm",
-            "-ldl",
-            "-std=c99",
-            "-o" + RustBuildTestCase.TEST_DIR + "/test_2_solvers"],
-            #stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
-
-        output, err = p.communicate()
-        rc = p.returncode
-
-        print("gcc output: ")
-        print(output.decode("utf-8"))
-        print("gcc err: ")
-        print(err.decode("utf-8"))
-        print("gcc rc: ")
-        print(rc)
-
-        if rc != 0:
-            exit(rc)
-
-        p = subprocess.Popen(["./" + RustBuildTestCase.TEST_DIR + "/test_2_solvers"],
-            #stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
-
-        output, err = p.communicate()
-        rc = p.returncode
-
-        print("test_2_solvers output: ")
-        print(output.decode("utf-8"))
-        print("test_2_solvers err: ")
-        print(err.decode("utf-8"))
-        print("test_2_solvers rc: ")
-        print(rc)
-
-        if rc != 0:
-            exit(rc)
-
-    def test_tcp_server(self):
-        tcp_manager = og.tcp.OptimizerTcpManager(
-            RustBuildTestCase.TEST_DIR + '/tcp_enabled_optimizer')
-        tcp_manager.start()
-
-        for i in range(100):
-            tcp_manager.ping()
-
-        for i in range(100):
-            # Note: invoking the server with a very low buffer length
-            #       to test whether the communication channel works
-            #       as expected
-            result = tcp_manager.call(p=[1.0, 10.0+i],
-                                      initial_guess=[1.0, 1.0, 2.0 + 0.5*i, 3.0, 4.0],
-                                      buffer_len=8)
-            _exit_status = result['exit_status']
-            self.assertEqual("Converged", _exit_status, "Problem not converged")
-
-        result = tcp_manager.call([1.0, 10.0, 100.0])
-        if 'type' not in result:
-            self.fail("No 'type' in result")
-        if 'code' not in result:
-            self.fail("No 'code' in result")
-
-        self.assertEqual(result['type'], "Error", "Error not detected")
-        self.assertEqual(result['code'], 3003, "Wrong error code")
-        tcp_manager.kill()
+    # def test_rust_build_without_penalty(self):
+    #     u = cs.SX.sym("u", 15)
+    #     p = cs.SX.sym("p", 2)
+    #     phi = og.functions.rosenbrock(u, p)
+    #     bounds = og.constraints.Ball2(None, 1.5)
+    #     problem = og.builder.Problem(u, p, phi)   \
+    #         .with_penalty_constraints(None)       \
+    #         .with_constraints(bounds)
+    #     build_config = og.config.BuildConfiguration()          \
+    #         .with_build_directory(RustBuildTestCase.TEST_DIR)  \
+    #         .with_build_mode("debug")
+    #     og.builder.OpEnOptimizerBuilder(problem, build_configuration=build_config) \
+    #         .with_generate_not_build_flag(False).build()
+    #
+    # def test_rust_build_with_tcp_server(self):
+    #     u = cs.SX.sym("u", 5)
+    #     p = cs.SX.sym("p", 2)
+    #     phi = og.functions.rosenbrock(u, p)
+    #     bounds = og.constraints.Ball2(None, 1.5)
+    #     problem = og.builder.Problem(u, p, phi) \
+    #         .with_penalty_constraints(None)     \
+    #         .with_constraints(bounds)
+    #     build_config = og.config.BuildConfiguration()         \
+    #         .with_build_directory(RustBuildTestCase.TEST_DIR) \
+    #         .with_build_mode("debug")                         \
+    #         .with_tcp_interface_config()
+    #     meta = og.config.OptimizerMeta()                      \
+    #         .with_optimizer_name("tcp_enabled_optimizer")
+    #     builder = og.builder.OpEnOptimizerBuilder(problem,
+    #                                               metadata=meta,
+    #                                               build_configuration=build_config) \
+    #         .with_generate_not_build_flag(False).with_verbosity_level(1)
+    #     builder.build()
+    #
+    # def test_fully_featured_release_mode(self):
+    #     u = cs.SX.sym("u", 5)
+    #     p = cs.SX.sym("p", 2)
+    #     phi = og.functions.rosenbrock(u, p)
+    #     c = cs.vertcat(1.5*u[0] - u[1], u[2] - u[3])
+    #     xmin = [-2.0, -2.0, -2.0, -2.0, -2.0]
+    #     xmax = [ 2.0,  2.0,  2.0,  2.0,  2.0]
+    #     bounds = og.constraints.Rectangle(xmin, xmax)
+    #     problem = og.builder.Problem(u, p, phi) \
+    #         .with_penalty_constraints(c)        \
+    #         .with_constraints(bounds)
+    #     meta = og.config.OptimizerMeta()                \
+    #         .with_version("0.0.0")                      \
+    #         .with_authors(["P. Sopasakis", "E. Fresk"]) \
+    #         .with_licence("CC4.0-By")                   \
+    #         .with_optimizer_name("the_optimizer")
+    #     build_config = og.config.BuildConfiguration()          \
+    #         .with_rebuild(False)                               \
+    #         .with_build_mode("debug")                          \
+    #         .with_build_directory(RustBuildTestCase.TEST_DIR)  \
+    #         .with_build_c_bindings()                           \
+    #         .with_tcp_interface_config()
+    #     solver_config = og.config.SolverConfiguration()   \
+    #         .with_lfbgs_memory(15)                        \
+    #         .with_tolerance(1e-5)                         \
+    #         .with_max_inner_iterations(155)               \
+    #         .with_delta_tolerance(1e-4)             \
+    #         .with_max_outer_iterations(15)                \
+    #         .with_penalty_weight_update_factor(8.0)       \
+    #         .with_initial_penalty_weights([20.0, 5.0]).with_cbfgs_parameters(1.0, 1e-8, 1e-9)
+    #     builder = og.builder.OpEnOptimizerBuilder(problem,
+    #                                               metadata=meta,
+    #                                               build_configuration=build_config,
+    #                                               solver_configuration=solver_config) \
+    #         .with_generate_not_build_flag(False).with_verbosity_level(0)
+    #     builder.build()
+    #
+    # def test_link_2_c_libs(self):
+    #     u = cs.SX.sym("u", 5)
+    #     p = cs.SX.sym("p", 2)
+    #     phi = og.functions.rosenbrock(u, p)
+    #     c = cs.vertcat(1.5*u[0] - u[1], u[2] - u[3])
+    #     xmin = [-2.0, -2.0, -2.0, -2.0, -2.0]
+    #     xmax = [ 2.0,  2.0,  2.0,  2.0,  2.0]
+    #     bounds = og.constraints.Rectangle(xmin, xmax)
+    #     problem = og.builder.Problem(u, p, phi) \
+    #         .with_penalty_constraints(c)        \
+    #         .with_constraints(bounds)
+    #     meta1 = og.config.OptimizerMeta()               \
+    #         .with_version("0.0.0")                      \
+    #         .with_authors(["P. Sopasakis", "E. Fresk"]) \
+    #         .with_licence("CC4.0-By")                   \
+    #         .with_optimizer_name("the_optimizer1")
+    #     meta2 = og.config.OptimizerMeta()               \
+    #         .with_version("0.0.0")                      \
+    #         .with_authors(["P. Sopasakis", "E. Fresk"]) \
+    #         .with_licence("CC4.0-By")                   \
+    #         .with_optimizer_name("the_optimizer2")
+    #     build_config = og.config.BuildConfiguration()          \
+    #         .with_rebuild(False)                               \
+    #         .with_build_mode("debug")                          \
+    #         .with_build_directory(RustBuildTestCase.TEST_DIR)  \
+    #         .with_build_c_bindings()
+    #     solver_config = og.config.SolverConfiguration()   \
+    #         .with_lfbgs_memory(15)                        \
+    #         .with_tolerance(1e-5)                         \
+    #         .with_max_inner_iterations(155)               \
+    #         .with_delta_tolerance(1e-4)             \
+    #         .with_max_outer_iterations(15)                \
+    #         .with_penalty_weight_update_factor(8.0)       \
+    #         .with_initial_penalty_weights([20.0, 5.0])
+    #
+    #     builder1 = og.builder.OpEnOptimizerBuilder(problem,
+    #                                               metadata=meta1,
+    #                                               build_configuration=build_config,
+    #                                               solver_configuration=solver_config) \
+    #         .with_generate_not_build_flag(False).with_verbosity_level(0)
+    #     builder1.build()
+    #
+    #     builder2 = og.builder.OpEnOptimizerBuilder(problem,
+    #                                               metadata=meta2,
+    #                                               build_configuration=build_config,
+    #                                               solver_configuration=solver_config) \
+    #         .with_generate_not_build_flag(False).with_verbosity_level(0)
+    #     builder2.build()
+    #
+    #     p = subprocess.Popen(["gcc",
+    #         "test/test_2_solvers.c",
+    #         "-I" + RustBuildTestCase.TEST_DIR + "/the_optimizer1",
+    #         "-I" + RustBuildTestCase.TEST_DIR + "/the_optimizer2",
+    #         "-pthread",
+    #         RustBuildTestCase.TEST_DIR + "/the_optimizer1/target/debug/libthe_optimizer1.a",
+    #         RustBuildTestCase.TEST_DIR + "/the_optimizer2/target/debug/libthe_optimizer2.a",
+    #         "-lm",
+    #         "-ldl",
+    #         "-std=c99",
+    #         "-o" + RustBuildTestCase.TEST_DIR + "/test_2_solvers"],
+    #         #stdin=subprocess.PIPE,
+    #         stdout=subprocess.PIPE,
+    #         stderr=subprocess.PIPE)
+    #
+    #     output, err = p.communicate()
+    #     rc = p.returncode
+    #
+    #     print("gcc output: ")
+    #     print(output.decode("utf-8"))
+    #     print("gcc err: ")
+    #     print(err.decode("utf-8"))
+    #     print("gcc rc: ")
+    #     print(rc)
+    #
+    #     if rc != 0:
+    #         exit(rc)
+    #
+    #     p = subprocess.Popen(["./" + RustBuildTestCase.TEST_DIR + "/test_2_solvers"],
+    #         #stdin=subprocess.PIPE,
+    #         stdout=subprocess.PIPE,
+    #         stderr=subprocess.PIPE)
+    #
+    #     output, err = p.communicate()
+    #     rc = p.returncode
+    #
+    #     print("test_2_solvers output: ")
+    #     print(output.decode("utf-8"))
+    #     print("test_2_solvers err: ")
+    #     print(err.decode("utf-8"))
+    #     print("test_2_solvers rc: ")
+    #     print(rc)
+    #
+    #     if rc != 0:
+    #         exit(rc)
+    #
+    # def test_tcp_server(self):
+    #     tcp_manager = og.tcp.OptimizerTcpManager(
+    #         RustBuildTestCase.TEST_DIR + '/tcp_enabled_optimizer')
+    #     tcp_manager.start()
+    #
+    #     for i in range(100):
+    #         tcp_manager.ping()
+    #
+    #     for i in range(100):
+    #         # Note: invoking the server with a very low buffer length
+    #         #       to test whether the communication channel works
+    #         #       as expected
+    #         result = tcp_manager.call(p=[1.0, 10.0+i],
+    #                                   initial_guess=[1.0, 1.0, 2.0 + 0.5*i, 3.0, 4.0],
+    #                                   buffer_len=8)
+    #         _exit_status = result['exit_status']
+    #         self.assertEqual("Converged", _exit_status, "Problem not converged")
+    #
+    #     result = tcp_manager.call([1.0, 10.0, 100.0])
+    #     if 'type' not in result:
+    #         self.fail("No 'type' in result")
+    #     if 'code' not in result:
+    #         self.fail("No 'code' in result")
+    #
+    #     self.assertEqual(result['type'], "Error", "Error not detected")
+    #     self.assertEqual(result['code'], 3003, "Wrong error code")
+    #     tcp_manager.kill()
 
 
 if __name__ == '__main__':

--- a/open-codegen/opengen/test/test.py
+++ b/open-codegen/opengen/test/test.py
@@ -227,101 +227,45 @@ class RustBuildTestCase(unittest.TestCase):
 
         mng.kill()
 
-    # def test_link_2_c_libs(self):
-    #     u = cs.SX.sym("u", 5)
-    #     p = cs.SX.sym("p", 2)
-    #     phi = og.functions.rosenbrock(u, p)
-    #     c = cs.vertcat(1.5*u[0] - u[1], u[2] - u[3])
-    #     xmin = [-2.0, -2.0, -2.0, -2.0, -2.0]
-    #     xmax = [ 2.0,  2.0,  2.0,  2.0,  2.0]
-    #     bounds = og.constraints.Rectangle(xmin, xmax)
-    #     problem = og.builder.Problem(u, p, phi) \
-    #         .with_penalty_constraints(c)        \
-    #         .with_constraints(bounds)
-    #     meta1 = og.config.OptimizerMeta()               \
-    #         .with_version("0.0.0")                      \
-    #         .with_authors(["P. Sopasakis", "E. Fresk"]) \
-    #         .with_licence("CC4.0-By")                   \
-    #         .with_optimizer_name("the_optimizer1")
-    #     meta2 = og.config.OptimizerMeta()               \
-    #         .with_version("0.0.0")                      \
-    #         .with_authors(["P. Sopasakis", "E. Fresk"]) \
-    #         .with_licence("CC4.0-By")                   \
-    #         .with_optimizer_name("the_optimizer2")
-    #     build_config = og.config.BuildConfiguration()          \
-    #         .with_rebuild(False)                               \
-    #         .with_build_mode("debug")                          \
-    #         .with_build_directory(RustBuildTestCase.TEST_DIR)  \
-    #         .with_build_c_bindings()
-    #     solver_config = og.config.SolverConfiguration()   \
-    #         .with_lfbgs_memory(15)                        \
-    #         .with_tolerance(1e-5)                         \
-    #         .with_max_inner_iterations(155)               \
-    #         .with_delta_tolerance(1e-4)             \
-    #         .with_max_outer_iterations(15)                \
-    #         .with_penalty_weight_update_factor(8.0)       \
-    #         .with_initial_penalty_weights([20.0, 5.0])
-    #
-    #     builder1 = og.builder.OpEnOptimizerBuilder(problem,
-    #                                               metadata=meta1,
-    #                                               build_configuration=build_config,
-    #                                               solver_configuration=solver_config) \
-    #         .with_generate_not_build_flag(False).with_verbosity_level(0)
-    #     builder1.build()
-    #
-    #     builder2 = og.builder.OpEnOptimizerBuilder(problem,
-    #                                               metadata=meta2,
-    #                                               build_configuration=build_config,
-    #                                               solver_configuration=solver_config) \
-    #         .with_generate_not_build_flag(False).with_verbosity_level(0)
-    #     builder2.build()
-    #
-    #     p = subprocess.Popen(["gcc",
-    #         "test/test_2_solvers.c",
-    #         "-I" + RustBuildTestCase.TEST_DIR + "/the_optimizer1",
-    #         "-I" + RustBuildTestCase.TEST_DIR + "/the_optimizer2",
-    #         "-pthread",
-    #         RustBuildTestCase.TEST_DIR + "/the_optimizer1/target/debug/libthe_optimizer1.a",
-    #         RustBuildTestCase.TEST_DIR + "/the_optimizer2/target/debug/libthe_optimizer2.a",
-    #         "-lm",
-    #         "-ldl",
-    #         "-std=c99",
-    #         "-o" + RustBuildTestCase.TEST_DIR + "/test_2_solvers"],
-    #         #stdin=subprocess.PIPE,
-    #         stdout=subprocess.PIPE,
-    #         stderr=subprocess.PIPE)
-    #
-    #     output, err = p.communicate()
-    #     rc = p.returncode
-    #
-    #     print("gcc output: ")
-    #     print(output.decode("utf-8"))
-    #     print("gcc err: ")
-    #     print(err.decode("utf-8"))
-    #     print("gcc rc: ")
-    #     print(rc)
-    #
-    #     if rc != 0:
-    #         exit(rc)
-    #
-    #     p = subprocess.Popen(["./" + RustBuildTestCase.TEST_DIR + "/test_2_solvers"],
-    #         #stdin=subprocess.PIPE,
-    #         stdout=subprocess.PIPE,
-    #         stderr=subprocess.PIPE)
-    #
-    #     output, err = p.communicate()
-    #     rc = p.returncode
-    #
-    #     print("test_2_solvers output: ")
-    #     print(output.decode("utf-8"))
-    #     print("test_2_solvers err: ")
-    #     print(err.decode("utf-8"))
-    #     print("test_2_solvers rc: ")
-    #     print(rc)
-    #
-    #     if rc != 0:
-    #         exit(rc)
-    #
+    @staticmethod
+    def c_bindings_helper(optimizer_name):
+        p = subprocess.Popen(["gcc",
+                              RustBuildTestCase.TEST_DIR + "/" + optimizer_name + "/example_optimizer.c",
+                              "-I" + RustBuildTestCase.TEST_DIR + "/" + optimizer_name,
+                              "-pthread",
+                              RustBuildTestCase.TEST_DIR + "/" + optimizer_name + "/target/debug/lib" + optimizer_name + ".a",
+                              "-lm",
+                              "-ldl",
+                              "-std=c99",
+                              "-o",
+                              RustBuildTestCase.TEST_DIR + "/" + optimizer_name + "/optimizer"],
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+
+        # Make sure it compiles
+        p.communicate()
+        rc1 = p.returncode
+
+        # Run the optimizer
+        p = subprocess.Popen([RustBuildTestCase.TEST_DIR + "/" + optimizer_name + "/optimizer"],
+                             stdout=subprocess.DEVNULL)
+        p.communicate()
+        rc2 = p.returncode
+
+        return rc1, rc2
+
+    def test_c_bindings(self):
+        rc1, rc2 = RustBuildTestCase.c_bindings_helper(optimizer_name="only_f1")
+        self.assertEqual(0, rc1)
+        self.assertEqual(0, rc2)
+
+        rc1, rc2 = RustBuildTestCase.c_bindings_helper(optimizer_name="only_f2")
+        self.assertEqual(0, rc1)
+        self.assertEqual(0, rc2)
+
+        rc1, rc2 = RustBuildTestCase.c_bindings_helper(optimizer_name="plain")
+        self.assertEqual(0, rc1)
+        self.assertEqual(0, rc2)
 
 
 if __name__ == '__main__':

--- a/open-codegen/opengen/test/test.py
+++ b/open-codegen/opengen/test/test.py
@@ -2,11 +2,105 @@ import unittest
 import casadi.casadi as cs
 import opengen as og
 import subprocess
-import json
+
 
 class RustBuildTestCase(unittest.TestCase):
 
     TEST_DIR = ".python_test_build"
+
+    @classmethod
+    def solverConfig(cls):
+        solver_config = og.config.SolverConfiguration() \
+            .with_lfbgs_memory(15) \
+            .with_tolerance(1e-4) \
+            .with_initial_tolerance(1e-4) \
+            .with_delta_tolerance(1e-4) \
+            .with_initial_penalty(15.0) \
+            .with_penalty_weight_update_factor(10.0) \
+            .with_max_inner_iterations(155) \
+            .with_max_duration_micros(1e8) \
+            .with_max_outer_iterations(50) \
+            .with_sufficient_decrease_coefficient(0.05) \
+            .with_cbfgs_parameters(1.5, 1e-10, 1e-12)
+        return solver_config
+
+    @classmethod
+    def setUpOnlyF1(cls):
+        u = cs.MX.sym("u", 5)  # decision variable (nu = 5)
+        p = cs.MX.sym("p", 2)  # parameter (np = 2)
+        f1 = cs.vertcat(1.5 * u[0] - u[1], u[2] - u[3])
+        set_c = og.constraints.BallInf([0.0, 0.1], 0.001)
+        set_y = og.constraints.BallInf(None, 1e12)
+        phi = og.functions.rosenbrock(u, p)  # cost function
+        bounds = og.constraints.Ball2(None, 1.5)  # ball centered at origin
+        tcp_config = og.config.TcpServerConfiguration(bind_port=3301)
+        meta = og.config.OptimizerMeta() \
+            .with_optimizer_name("only_f1")
+        problem = og.builder.Problem(u, p, phi) \
+            .with_aug_lagrangian_constraints(f1, set_c, set_y) \
+            .with_constraints(bounds)
+        build_config = og.config.BuildConfiguration() \
+            .with_build_directory(RustBuildTestCase.TEST_DIR) \
+            .with_build_mode("debug") \
+            .with_tcp_interface_config(tcp_interface_config=tcp_config) \
+            .with_build_c_bindings()
+        og.builder.OpEnOptimizerBuilder(problem,
+                                        metadata=meta,
+                                        build_configuration=build_config,
+                                        solver_configuration=cls.solverConfig()) \
+            .build()
+
+    @classmethod
+    def setUpOnlyF2(cls):
+        u = cs.MX.sym("u", 5)  # decision variable (nu = 5)
+        p = cs.MX.sym("p", 2)  # parameter (np = 2)
+        f2 = cs.vertcat(0.2 + 1.5 * u[0] - u[1], u[2] - u[3] - 0.1)
+        phi = og.functions.rosenbrock(u, p)
+        bounds = og.constraints.Ball2(None, 1.5)
+        tcp_config = og.config.TcpServerConfiguration(bind_port=3302)
+        meta = og.config.OptimizerMeta() \
+            .with_optimizer_name("only_f2")
+        problem = og.builder.Problem(u, p, phi) \
+            .with_penalty_constraints(f2) \
+            .with_constraints(bounds)
+        build_config = og.config.BuildConfiguration() \
+            .with_build_directory(RustBuildTestCase.TEST_DIR) \
+            .with_build_mode("debug") \
+            .with_tcp_interface_config(tcp_interface_config=tcp_config) \
+            .with_build_c_bindings()
+        og.builder.OpEnOptimizerBuilder(problem,
+                                        metadata=meta,
+                                        build_configuration=build_config,
+                                        solver_configuration=cls.solverConfig()) \
+            .build()
+
+    @classmethod
+    def setUpPlain(cls):
+        u = cs.MX.sym("u", 5)  # decision variable (nu = 5)
+        p = cs.MX.sym("p", 2)  # parameter (np = 2)
+        phi = og.functions.rosenbrock(u, p)
+        bounds = og.constraints.Ball2(None, 1.5)
+        tcp_config = og.config.TcpServerConfiguration(bind_port=3302)
+        meta = og.config.OptimizerMeta() \
+            .with_optimizer_name("plain")
+        problem = og.builder.Problem(u, p, phi) \
+            .with_constraints(bounds)
+        build_config = og.config.BuildConfiguration() \
+            .with_build_directory(RustBuildTestCase.TEST_DIR) \
+            .with_build_mode("debug") \
+            .with_tcp_interface_config(tcp_interface_config=tcp_config) \
+            .with_build_c_bindings()
+        og.builder.OpEnOptimizerBuilder(problem,
+                                        metadata=meta,
+                                        build_configuration=build_config,
+                                        solver_configuration=cls.solverConfig()) \
+            .build()
+
+    @classmethod
+    def setUpClass(cls):
+        cls.setUpOnlyF1()
+        cls.setUpOnlyF2()
+        cls.setUpPlain()
 
     def test_rectangle_empty(self):
         xmin = [-1, 2]
@@ -61,169 +155,76 @@ class RustBuildTestCase(unittest.TestCase):
             og.config.SolverConfiguration().with_max_inner_iterations()
 
     def test_rust_build_only_f1(self):
-        u = cs.MX.sym("u", 5)  # decision variable (nu = 5)
-        p = cs.MX.sym("p", 2)  # parameter (np = 2)
-        f1 = cs.vertcat(1.5 * u[0] - u[1], u[2] - u[3])
-        set_c = og.constraints.BallInf([0.0, 0.1], 0.001)
-        set_y = og.constraints.BallInf(None, 1e12)
-        phi = og.functions.rosenbrock(u, p)  # cost function
-        bounds = og.constraints.Ball2(None, 1.5)  # ball centered at origin
-        problem = og.builder.Problem(u, p, phi) \
-            .with_aug_lagrangian_constraints(f1, set_c, set_y) \
-            .with_constraints(bounds)
-        build_config = og.config.BuildConfiguration() \
-            .with_build_directory(RustBuildTestCase.TEST_DIR) \
-            .with_build_mode("debug") \
-            .with_tcp_interface_config()
-        solver_config = og.config.SolverConfiguration() \
-            .with_lfbgs_memory(15) \
-            .with_tolerance(1e-4) \
-            .with_initial_tolerance(1e-4) \
-            .with_delta_tolerance(1e-4) \
-            .with_initial_penalty(15.0) \
-            .with_penalty_weight_update_factor(10.0) \
-            .with_max_inner_iterations(155) \
-            .with_max_duration_micros(1e8) \
-            .with_max_outer_iterations(50) \
-            .with_sufficient_decrease_coefficient(0.05) \
-            .with_cbfgs_parameters(1.5, 1e-10, 1e-12)
-        og.builder.OpEnOptimizerBuilder(problem,
-                                        build_configuration=build_config,
-                                        solver_configuration=solver_config) \
-            .build()
-        mng = og.tcp.OptimizerTcpManager(RustBuildTestCase.TEST_DIR + '/open_optimizer')
+        mng = og.tcp.OptimizerTcpManager(RustBuildTestCase.TEST_DIR + '/only_f1')
         mng.start()
         pong = mng.ping()  # check if the server is alive
-        print(pong)
+        self.assertEqual(1, pong["Pong"])
+
+        # Regular call
         response = mng.call(p=[2.0, 10.0])
-        mng.kill()
         self.assertEqual("Converged", response["exit_status"])
-        print(json.dumps(response, indent=4, sort_keys=False))
+
+        # Call with initial params, initial y and initial penalty param
+        response = mng.call(p=[2.0, 10.0],
+                            initial_guess=response["solution"],
+                            initial_y=response["lagrange_multipliers"],
+                            initial_penalty=response["penalty"])
+        self.assertEqual(2, response["num_outer_iterations"])
+
+        response = mng.call(p=[2.0, 10.0, 50.0])
+        self.assertEqual("Error", response["type"])
+        self.assertEqual(3003, response["code"])
+
+        response = mng.call(p=[2.0, 10.0], initial_guess=[0.1, 0.2])
+        self.assertEqual("Error", response["type"])
+        self.assertEqual(1600, response["code"])
+
+        response = mng.call(p=[2.0, 10.0], initial_y=[0.1])
+        self.assertEqual("Error", response["type"])
+        self.assertEqual(1700, response["code"])
+
+        mng.kill()
 
     def test_rust_build_only_f2(self):
-        u = cs.SX.sym("u", 15)
-        p = cs.SX.sym("p", 2)
-        phi = og.functions.rosenbrock(u, p)
-        f2 = cs.vertcat(1.5 * u[0] - u[1], u[2] - u[3])
-        bounds = og.constraints.Ball2(None, 1.5)
-        problem = og.builder.Problem(u, p, phi) \
-            .with_penalty_constraints(f2) \
-            .with_constraints(bounds)
-        build_config = og.config.BuildConfiguration() \
-            .with_build_directory(RustBuildTestCase.TEST_DIR) \
-            .with_build_mode("debug")
-        og.builder.OpEnOptimizerBuilder(problem, build_configuration=build_config) \
-            .build()
+        mng = og.tcp.OptimizerTcpManager(RustBuildTestCase.TEST_DIR + '/only_f2')
+        mng.start()
+        pong = mng.ping()  # check if the server is alive
+        self.assertEqual(1, pong["Pong"])
 
-    def test_rust_build_only_f1_and_f2(self):
-        u = cs.SX.sym("u", 15)
-        p = cs.SX.sym("p", 2)
-        phi = og.functions.rosenbrock(u, p)
-        f1 = cs.vertcat(1.5 * u[0] - u[1], u[2] - u[3])
-        f2 = cs.vertcat(u[4] - 1.0, u[5], cs.sin(u[6]), cs.cos(u[7]+u[8]))
-        set_c = og.constraints.Ball2([0.1, 0.1], 1)
-        set_y = og.constraints.BallInf(None, 1e12)
-        bounds = og.constraints.BallInf(None, 1.5)
-        problem = og.builder.Problem(u, p, phi) \
-            .with_aug_lagrangian_constraints(f1, set_c, set_y) \
-            .with_penalty_constraints(f2) \
-            .with_constraints(bounds)
-        build_config = og.config.BuildConfiguration() \
-            .with_build_directory(RustBuildTestCase.TEST_DIR) \
-            .with_build_mode("debug")
-        og.builder.OpEnOptimizerBuilder(problem, build_configuration=build_config) \
-            .build()
+        # Regular call
+        response = mng.call(p=[2.0, 10.0])
+        self.assertEqual("Converged", response["exit_status"])
 
-    def test_rust_build_only_no_f1_no_f2(self):
-        u = cs.SX.sym("u", 15)
-        p = cs.SX.sym("p", 2)
-        phi = og.functions.rosenbrock(u, p)
-        f1 = cs.vertcat(1.5 * u[0] - u[1], u[2] - u[3])
-        f2 = cs.vertcat(u[4] - 1.0, u[5], cs.sin(u[6]), cs.cos(u[7]+u[8]))
-        set_c = og.constraints.Ball2(None, 1)
-        set_y = og.constraints.BallInf(None, 1e12)
-        bounds = og.constraints.BallInf(None, 1.5)
-        problem = og.builder.Problem(u, p, phi) \
-            .with_aug_lagrangian_constraints(f1, set_c, set_y) \
-            .with_penalty_constraints(f2) \
-            .with_constraints(bounds)
-        build_config = og.config.BuildConfiguration() \
-            .with_build_directory(RustBuildTestCase.TEST_DIR) \
-            .with_build_mode("debug")
-        og.builder.OpEnOptimizerBuilder(problem, build_configuration=build_config) \
-            .build()
+        # Call with initial params, initial y and initial penalty param
+        response = mng.call(p=[2.0, 10.0],
+                            initial_guess=response["solution"],
+                            initial_penalty=response["penalty"])
+        self.assertEqual(1, response["num_outer_iterations"])
 
-    # def test_rust_build_without_penalty(self):
-    #     u = cs.SX.sym("u", 15)
-    #     p = cs.SX.sym("p", 2)
-    #     phi = og.functions.rosenbrock(u, p)
-    #     bounds = og.constraints.Ball2(None, 1.5)
-    #     problem = og.builder.Problem(u, p, phi)   \
-    #         .with_penalty_constraints(None)       \
-    #         .with_constraints(bounds)
-    #     build_config = og.config.BuildConfiguration()          \
-    #         .with_build_directory(RustBuildTestCase.TEST_DIR)  \
-    #         .with_build_mode("debug")
-    #     og.builder.OpEnOptimizerBuilder(problem, build_configuration=build_config) \
-    #         .with_generate_not_build_flag(False).build()
-    #
-    # def test_rust_build_with_tcp_server(self):
-    #     u = cs.SX.sym("u", 5)
-    #     p = cs.SX.sym("p", 2)
-    #     phi = og.functions.rosenbrock(u, p)
-    #     bounds = og.constraints.Ball2(None, 1.5)
-    #     problem = og.builder.Problem(u, p, phi) \
-    #         .with_penalty_constraints(None)     \
-    #         .with_constraints(bounds)
-    #     build_config = og.config.BuildConfiguration()         \
-    #         .with_build_directory(RustBuildTestCase.TEST_DIR) \
-    #         .with_build_mode("debug")                         \
-    #         .with_tcp_interface_config()
-    #     meta = og.config.OptimizerMeta()                      \
-    #         .with_optimizer_name("tcp_enabled_optimizer")
-    #     builder = og.builder.OpEnOptimizerBuilder(problem,
-    #                                               metadata=meta,
-    #                                               build_configuration=build_config) \
-    #         .with_generate_not_build_flag(False).with_verbosity_level(1)
-    #     builder.build()
-    #
-    # def test_fully_featured_release_mode(self):
-    #     u = cs.SX.sym("u", 5)
-    #     p = cs.SX.sym("p", 2)
-    #     phi = og.functions.rosenbrock(u, p)
-    #     c = cs.vertcat(1.5*u[0] - u[1], u[2] - u[3])
-    #     xmin = [-2.0, -2.0, -2.0, -2.0, -2.0]
-    #     xmax = [ 2.0,  2.0,  2.0,  2.0,  2.0]
-    #     bounds = og.constraints.Rectangle(xmin, xmax)
-    #     problem = og.builder.Problem(u, p, phi) \
-    #         .with_penalty_constraints(c)        \
-    #         .with_constraints(bounds)
-    #     meta = og.config.OptimizerMeta()                \
-    #         .with_version("0.0.0")                      \
-    #         .with_authors(["P. Sopasakis", "E. Fresk"]) \
-    #         .with_licence("CC4.0-By")                   \
-    #         .with_optimizer_name("the_optimizer")
-    #     build_config = og.config.BuildConfiguration()          \
-    #         .with_rebuild(False)                               \
-    #         .with_build_mode("debug")                          \
-    #         .with_build_directory(RustBuildTestCase.TEST_DIR)  \
-    #         .with_build_c_bindings()                           \
-    #         .with_tcp_interface_config()
-    #     solver_config = og.config.SolverConfiguration()   \
-    #         .with_lfbgs_memory(15)                        \
-    #         .with_tolerance(1e-5)                         \
-    #         .with_max_inner_iterations(155)               \
-    #         .with_delta_tolerance(1e-4)             \
-    #         .with_max_outer_iterations(15)                \
-    #         .with_penalty_weight_update_factor(8.0)       \
-    #         .with_initial_penalty_weights([20.0, 5.0]).with_cbfgs_parameters(1.0, 1e-8, 1e-9)
-    #     builder = og.builder.OpEnOptimizerBuilder(problem,
-    #                                               metadata=meta,
-    #                                               build_configuration=build_config,
-    #                                               solver_configuration=solver_config) \
-    #         .with_generate_not_build_flag(False).with_verbosity_level(0)
-    #     builder.build()
-    #
+        response = mng.call(p=[2.0, 10.0, 50.0])
+        self.assertEqual("Error", response["type"])
+        self.assertEqual(3003, response["code"])
+
+        response = mng.call(p=[2.0, 10.0], initial_guess=[0.1, 0.2])
+        self.assertEqual("Error", response["type"])
+        self.assertEqual(1600, response["code"])
+
+        response = mng.call(p=[2.0, 10.0], initial_y=[0.1])
+        self.assertEqual("Error", response["type"])
+        self.assertEqual(1700, response["code"])
+
+        mng.kill()
+
+    def test_rust_build_only_f2(self):
+        mng = og.tcp.OptimizerTcpManager(RustBuildTestCase.TEST_DIR + '/plain')
+        mng.start()
+        pong = mng.ping()  # check if the server is alive
+        self.assertEqual(1, pong["Pong"])
+
+        # Regular call
+        response = mng.call(p=[2.0, 10.0])
+        self.assertEqual("Converged", response["exit_status"])
+
     # def test_link_2_c_libs(self):
     #     u = cs.SX.sym("u", 5)
     #     p = cs.SX.sym("p", 2)
@@ -319,34 +320,7 @@ class RustBuildTestCase(unittest.TestCase):
     #     if rc != 0:
     #         exit(rc)
     #
-    # def test_tcp_server(self):
-    #     tcp_manager = og.tcp.OptimizerTcpManager(
-    #         RustBuildTestCase.TEST_DIR + '/tcp_enabled_optimizer')
-    #     tcp_manager.start()
-    #
-    #     for i in range(100):
-    #         tcp_manager.ping()
-    #
-    #     for i in range(100):
-    #         # Note: invoking the server with a very low buffer length
-    #         #       to test whether the communication channel works
-    #         #       as expected
-    #         result = tcp_manager.call(p=[1.0, 10.0+i],
-    #                                   initial_guess=[1.0, 1.0, 2.0 + 0.5*i, 3.0, 4.0],
-    #                                   buffer_len=8)
-    #         _exit_status = result['exit_status']
-    #         self.assertEqual("Converged", _exit_status, "Problem not converged")
-    #
-    #     result = tcp_manager.call([1.0, 10.0, 100.0])
-    #     if 'type' not in result:
-    #         self.fail("No 'type' in result")
-    #     if 'code' not in result:
-    #         self.fail("No 'code' in result")
-    #
-    #     self.assertEqual(result['type'], "Error", "Error not detected")
-    #     self.assertEqual(result['code'], 3003, "Wrong error code")
-    #     tcp_manager.kill()
 
-
+    
 if __name__ == '__main__':
     unittest.main()

--- a/open-codegen/opengen/test/test_2_solvers.c
+++ b/open-codegen/opengen/test/test_2_solvers.c
@@ -1,3 +1,6 @@
+/*
+ * Deprecated - to be removed in the future
+ */
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>

--- a/src/alm/alm_optimizer.rs
+++ b/src/alm/alm_optimizer.rs
@@ -890,15 +890,26 @@ where
             0.0
         };
 
-        Ok(AlmOptimizerStatus::new(exit_status)
+        let status = AlmOptimizerStatus::new(exit_status)
             .with_solve_time(tic.elapsed())
             .with_inner_iterations(self.alm_cache.inner_iteration_count)
             .with_outer_iterations(num_outer_iterations)
-            .with_lagrange_multipliers(&self.alm_cache.y_plus.as_ref().unwrap_or(&Vec::new()))
             .with_last_problem_norm_fpr(self.alm_cache.last_inner_problem_norm_fpr)
             .with_delta_y_norm(self.alm_cache.delta_y_norm_plus)
             .with_f2_norm(self.alm_cache.f2_norm_plus)
-            .with_penalty(c))
+            .with_penalty(c);
+        if self.alm_problem.n1 > 0 {
+            let status = status.with_lagrange_multipliers(
+                &self
+                    .alm_cache
+                    .y_plus
+                    .as_ref()
+                    .expect("Although n1 > 0, there is no vector y (Lagrange multipliers)"),
+            );
+            Ok(status)
+        } else {
+            Ok(status)
+        }
     }
 }
 


### PR DESCRIPTION
Re-introduced and updated Python tests:

- Using `setUpClass` to generated optimizers on start up
- Testing solver behaviour and error codes (over TCP)
- Creating C interface with bidgen
- Running generated C code