### PR TITLE
Problems without constraints

### DIFF
--- a/open-codegen/opengen/builder/problem.py
+++ b/open-codegen/opengen/builder/problem.py
@@ -1,5 +1,6 @@
 import casadi.casadi as cs
 from .set_y_calculator import SetYCalculator
+from ..constraints.no_constraints import NoConstraints
 
 
 class Problem:
@@ -36,7 +37,7 @@ class Problem:
         # Cost function: f(u, p)
         self.__cost = cost
         # Constraints on u: u in U
-        self.__u_constraints = None
+        self.__u_constraints = NoConstraints()
         # ALM-type constraints: mapping F1(u, p)
         self.__alm_mapping_f1 = None
         # ALM-type constraints: set C

--- a/open-codegen/opengen/constraints/ball2.py
+++ b/open-codegen/opengen/constraints/ball2.py
@@ -12,7 +12,7 @@ class Ball2(Constraint):
 
     """
 
-    def __init__(self, center, radius: float):
+    def __init__(self, center=None, radius: float = 1.0):
         """Constructor for a Euclidean ball constraint
 
         Args:

--- a/open-codegen/opengen/constraints/ball_inf.py
+++ b/open-codegen/opengen/constraints/ball_inf.py
@@ -10,7 +10,7 @@ class BallInf(Constraint):
     Centered inf-ball around given point
     """
 
-    def __init__(self, center, radius: float):
+    def __init__(self, center=None, radius: float = 0.0):
         """Constructor for an infinity ball constraint
 
         Args:


### PR DESCRIPTION
If a problem has no constraints, the user shouldn't be obliged to write

```python
problem.with_constraints(og.NoConstraints())
```

This is fixed in this PR.