### PR TITLE
added deny missing docs macro to lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! **Optimization Engine** is a framework for **fast** and **accurate** embedded nonconvex optimization.
 //!
 //! # About Optimization Engine


### PR DESCRIPTION
#85 
@alphaville 
Adds the deny(missing_docs) macro to check for docs in library.