### PR TITLE
Separate job for macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,24 @@ jobs:
           python-version: '3.x'
           architecture: 'x64'
       - run: bash ./ci/script.sh
+  
+  ci_macos:
+    runs-on: macos-latest
+    env:
+      DO_DOCKER: 0
+    steps:
+      - uses: actions/checkout@v2
+      - run: brew install llvm
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+      - run: bash ./ci/script.sh


### PR DESCRIPTION
`clang` is not included by default in GitHub actions any more, so we need to install it; on macos, the installation needs to be done using `brew`, so we had to create a separate job for that.