### PR TITLE
GitHub Actions Settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,10 @@ jobs:
       - run: bash ./ci/script.sh
 
   ci_macos:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-11, macos-10.15]
     env:
       DO_DOCKER: 0
     steps:


### PR DESCRIPTION
Changes: 

- ubuntu-16.04 is a deprecated OS (since 9/2021)
- MacOS: new CI matrix