### PR TITLE
Fix documentation link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! (e.g., Raspberry Pi, Atom, Odroid, etc).
 //!
 //! Note that this is the **API documentation** of **Optimization Engine**; to get started,
-//! you would rather check out the [documentation]().
+//! you would rather check out the [documentation](https://alphaville.github.io/optimization-engine/).
 //!
 //! # Optimization Problems
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! (e.g., Raspberry Pi, Atom, Odroid, etc).
 //!
 //! Note that this is the **API documentation** of **Optimization Engine**; to get started,
-//! you would rather check out the [documentation](https://alphaville.github.io/optimization-engine/).
+//! you should rather check out the [documentation](https://alphaville.github.io/optimization-engine/).
 //!
 //! # Optimization Problems
 //!


### PR DESCRIPTION
API doc says `Note that this is the API documentation of Optimization Engine; to get started, you would rather check out the documentation.`, and then points back to itself. I guess this should have been a link to https://alphaville.github.io/optimization-engine/
