### PR TITLE
Quick fixes and compatibility with python 3.5

### DIFF
--- a/docs/openrust-alm.md
+++ b/docs/openrust-alm.md
@@ -42,7 +42,7 @@ pub fn df(u: &[f64], grad: &mut [f64]) -> Result<(), SolverError> {
 Suppose we need to impose the constraint $F_1(u) \in C$, where $C=\\{z\in\mathbb{R}^2: \Vert{}z{}\Vert \leq 1\\}$
 and $F_1$ is the mapping 
 $$
-F_1(u)=\begin{bmatrix}2u_1 + u_1 + 0.5 \\\\ u_1+3u_2\end{bmatrix}
+F_1(u)=\begin{bmatrix}2u_1 + u_3 + 0.5 \\\\ u_1+3u_2\end{bmatrix}
 $$
 
 ```rust

--- a/open-codegen/opengen/builder/optimizer_builder.py
+++ b/open-codegen/opengen/builder/optimizer_builder.py
@@ -466,15 +466,15 @@ class OpEnOptimizerBuilder:
          target_lib_extension) = pltform_extension_dict[sys.platform]
         optimizer_prefix = "lib" if sys.platform != "win32" else ""
         generated_bindings = os.path.join(
-            build_dir, f"{optimizer_prefix}{optimizer_name}{original_lib_extension}")
+            build_dir, "{}{}{}".format(optimizer_prefix, optimizer_name, original_lib_extension))
         target_bindings = os.path.join(
-            target_dir, f"{optimizer_name}{target_lib_extension}")
+            target_dir, "{}{}".format(optimizer_name, target_lib_extension))
         shutil.copyfile(generated_bindings, target_bindings)
-        self.__logger.info(f"To use the Python bindings do:\n\n"
-                           f"       import sys\n"
-                           f"       sys.path.insert(1, \"{target_dir}\")\n"
-                           f"       import {optimizer_name}\n"
-                           f"       solver = {optimizer_name}.solver()")
+        self.__logger.info("To use the Python bindings do:\n\n"
+                           "       import sys\n"
+                           "       sys.path.insert(1, \"{}\")\n"
+                           "       import {}\n"
+                           "       solver = {}.solver()".format(target_dir, optimizer_name, optimizer_name))
 
     def __build_tcp_iface(self):
         self.__logger.info("Building the TCP interface")
@@ -503,7 +503,7 @@ class OpEnOptimizerBuilder:
             target_dir, python_bindings_dir_name)
         python_bindings_source_dir = os.path.join(python_bindings_dir, "src")
         self.__logger.info(
-            f"Generating code for Python bindings in {python_bindings_dir}")
+            "Generating code for Python bindings in {}".format(python_bindings_dir))
 
         # make python_bindings/ and python_bindings/src
         make_dir_if_not_exists(python_bindings_dir)

--- a/open-codegen/opengen/templates/tcp/tcp_server.rs
+++ b/open-codegen/opengen/templates/tcp/tcp_server.rs
@@ -210,7 +210,7 @@ fn run_server(tcp_config: &TcpServerConfiguration) {
         while read_data_length != 0 {
             read_data_length = stream
                 .read(&mut bytes_buffer)
-                .expect("count not read stream");
+                .expect("could not read stream");
             let new_string = String::from_utf8(bytes_buffer[0..read_data_length].to_vec())
                 .expect("sent data is not UFT-8");
             buffer.push_str(&new_string);


### PR DESCRIPTION
## Main Changes

- change f-strings (`f"{variable}"`) to `.format` for python3.5 compatibility
- fix typo in `tcp_server.rs`


## TODOs

- [ ] Update `CHANGELOG`(s)


