### PR TITLE
Preconditioning in auto-generated solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note: This is the main Changelog file for the Rust solver. The Changelog file fo
 <!-- ---------------------
       Unreleased
      --------------------- -->
+## [v0.7.6] - Unreleased
+
+### Added
+
+- Update functions in `AlmOptimizerStatus`
+
 
 
 <!-- ---------------------
@@ -230,6 +236,7 @@ This is a breaking API change.
      --------------------- -->
 
 <!-- Releases -->
+[v0.7.6]: https://github.com/alphaville/optimization-engine/compare/v0.7.5...v0.7.6 
 [v0.7.5]: https://github.com/alphaville/optimization-engine/compare/v0.7.4...v0.7.5 
 [v0.7.4]: https://github.com/alphaville/optimization-engine/compare/v0.7.3...v0.7.4
 [v0.7.3]: https://github.com/alphaville/optimization-engine/compare/v0.7.2...v0.7.3

--- a/open-codegen/opengen/builder/optimizer_builder.py
+++ b/open-codegen/opengen/builder/optimizer_builder.py
@@ -305,9 +305,11 @@ class OpEnOptimizerBuilder:
         f1 = problem.penalty_mapping_f1
         f2 = problem.penalty_mapping_f2
         w_cost = problem.w_cost
+        w1 = problem.w1
+        w2 = problem.w2
         theta = cs.vertcat(p, problem.preconditioning_coefficients)
 
-        psi = phi
+        psi = w_cost * phi
 
         if n1 + n2 > 0:
             n_xi = n1 + 1
@@ -322,13 +324,12 @@ class OpEnOptimizerBuilder:
         #       retrieve the value of the original cost function
         if n1 > 0:
             sq_dist_term = alm_set_c.distance_squared(
-                f1 + xi[1:n1+1]/cs.fmax(xi[0], 1))
+                w1 * f1 + xi[1:n1+1]/cs.fmax(xi[0], 1))
             psi += xi[0] * sq_dist_term / 2
 
         if n2 > 0:
-            psi += xi[0] * cs.dot(f2, f2) / 2
+            psi += xi[0] * cs.dot(w2*f2, w2*f2) / 2
 
-        psi = w_cost * psi
         jac_psi = cs.gradient(psi, u)
 
         psi_fun = cs.Function(meta.cost_function_name, [u, xi, theta], [psi])

--- a/open-codegen/opengen/config/solver_config.py
+++ b/open-codegen/opengen/config/solver_config.py
@@ -16,7 +16,9 @@ class SolverConfiguration:
         self.__max_inner_iterations = 500
         self.__max_outer_iterations = 10
         self.__constraints_tolerance = 1e-4
-        self.__initial_penalty = 1.0
+        # For the initial penalty, None means that the actual value will be computed
+        # in Rust (see templates/optimizer.rs)
+        self.__initial_penalty = None
         self.__penalty_weight_update_factor = 5.0
         self.__max_duration_micros = 5000000
         self.__inner_tolerance_update_factor = 0.1
@@ -126,10 +128,22 @@ class SolverConfiguration:
     def with_initial_penalty(self, initial_penalty):
         """Initial penalty
 
+        If preconditioning is activated, then the initial penalty is computed internally
+        following the recommendations of the book of Brigin and Martinez (Chapter 12).
+        If you enable the preconditioning and you use this method, then you will be
+        overriding the value of the initial penalty.
+
+        If preconditioning is not enabled, you can set the initial penalty using this
+        method; if you don't do so, the solver will use the default value (which is 1.0).
+
         :param initial_penalty: initial value of penalty
 
         :returns: The current object
         """
+        if initial_penalty is None:
+            self.__initial_penalty = None
+            return
+
         if initial_penalty <= 0:
             raise Exception("Initial penalty must be >0")
 

--- a/open-codegen/opengen/constraints/halfspace.py
+++ b/open-codegen/opengen/constraints/halfspace.py
@@ -9,14 +9,14 @@ class Halfspace(Constraint):
     vector and b is a constant scalar.
     """
 
-    def __init__(self, normal_vector, offset):
+    def __init__(self, normal_vector, offset: float):
         """Construct a new halfspace H = {c'x <= b}
 
         :param normal_vector: vector c
         "param offset: parameter b
         """
         self.__normal_vector = [float(x) for x in normal_vector]
-        self.__offset = offset
+        self.__offset = float(offset)
 
     @property
     def normal_vector(self):

--- a/open-codegen/opengen/main.py
+++ b/open-codegen/opengen/main.py
@@ -10,7 +10,7 @@ optimizer_name = "rosenbrock"
 nu, np = 5, 2
 u = cs.SX.sym("u", nu)  # decision variable (nu = 5)
 p = cs.SX.sym("p", 2)  # parameter (np = 2)
-phi = og.functions.rosenbrock(u, p)
+phi = og.functions.rosenbrock(u, p) + 1500*cs.sum1(u)
 
 # c_f1 = cs.vertcat(p[0] * u[0] - u[1], p[1]*u[2] - u[3] + 0.1)
 c_f2 = cs.vertcat(0.2 + 1.5 * u[0] - u[1], u[2] - u[3] - 0.1)
@@ -25,7 +25,8 @@ meta = og.config.OptimizerMeta()\
 build_config = og.config.BuildConfiguration() \
     .with_build_directory(optimizers_dir) \
     .with_build_mode(og.config.BuildConfiguration.DEBUG_MODE) \
-    .with_build_python_bindings()
+    .with_build_python_bindings() \
+    .with_open_version(local_path="/Users/3054363/Documents/Development/OpEn/")
 solver_cfg = og.config.SolverConfiguration() \
     .with_tolerance(1e-6) \
     .with_max_inner_iterations(1000) \
@@ -53,6 +54,7 @@ print(f"infeasibility f2 = {result.f2_norm}")
 print(f"status = {result.exit_status}")
 print(f"inner = {result.num_inner_iterations}")
 print(f"outer = {result.num_outer_iterations}")
+print(f"cost = {result.cost}")
 
 # Preconditioned    Non-preconditioned
 # -------------------------------------

--- a/open-codegen/opengen/main.py
+++ b/open-codegen/opengen/main.py
@@ -46,7 +46,7 @@ sys.path.insert(1, os.path.join(optimizers_dir, optimizer_name))
 rosenbrock = __import__(optimizer_name)
 
 solver = rosenbrock.solver()
-result = solver.run(p=[1., 2.], initial_guess=[1, 1, 1, 1, 1])
+result = solver.run(p=[3.5, 7.8], initial_guess=[1, 2, 3, 4, 5])
 print(" ")
 print(f"solution = {result.solution}")
 print(f"time = {result.solve_time_ms} ms")

--- a/open-codegen/opengen/main.py
+++ b/open-codegen/opengen/main.py
@@ -10,30 +10,28 @@ optimizer_name = "rosenbrock"
 nu, np = 5, 2
 u = cs.SX.sym("u", nu)  # decision variable (nu = 5)
 p = cs.SX.sym("p", 2)  # parameter (np = 2)
-phi = 0.5 * p[0] * cs.dot(u, u)
+phi = og.functions.rosenbrock(u, p)
 for i in range(nu):
     phi = phi + p[1] * cs.sin(u[i])
 
-
 c_f1 = cs.vertcat(p[0] * u[0] - u[1], p[1]*u[2] - u[3] + 0.1)
-c_f2 = cs.vertcat((u[2]+1)**2 - 8*u[4], 5*cs.sin(u[3] + 1))
 
 bounds = og.constraints.Halfspace([1, 1, 1, 1, 1], 100)
 problem = og.builder.Problem(u, p, phi) \
-    .with_penalty_constraints(c_f2)\
     .with_aug_lagrangian_constraints(c_f1, og.constraints.Zero())\
     .with_constraints(bounds)
 meta = og.config.OptimizerMeta() \
     .with_optimizer_name(optimizer_name)
 
-tcp_config = og.config.TcpServerConfiguration(bind_port=3305)
 build_config = og.config.BuildConfiguration() \
     .with_build_directory(optimizers_dir) \
     .with_build_mode(og.config.BuildConfiguration.DEBUG_MODE) \
-    .with_build_python_bindings() \
-    .with_tcp_interface_config()
+    .with_build_python_bindings()
 solver_cfg = og.config.SolverConfiguration() \
     .with_tolerance(1e-6) \
+    .with_max_inner_iterations(1000) \
+    .with_max_outer_iterations(20) \
+    .with_penalty_weight_update_factor(1.3) \
     .with_preconditioning(True)
 
 builder = og.builder.OpEnOptimizerBuilder(problem,
@@ -46,7 +44,7 @@ sys.path.insert(1, os.path.join(optimizers_dir, optimizer_name))
 rosenbrock = __import__(optimizer_name)
 
 solver = rosenbrock.solver()
-result = solver.run(p=[3.5, 7.8], initial_guess=[1, 2, 3, 4, 5])
+result = solver.run(p=[0.5, 8.5], initial_guess=[1, 2, 3, 4, 0])
 print(" ")
 print(f"solution = {result.solution}")
 print(f"time = {result.solve_time_ms} ms")
@@ -54,5 +52,8 @@ print(f"penalty = {result.penalty}")
 print(f"infeasibility f1 = {result.f1_infeasibility}")
 print(f"infeasibility f2 = {result.f2_norm}")
 print(f"status = {result.exit_status}")
+print(f"inner = {result.num_inner_iterations}")
+print(f"outer = {result.num_outer_iterations}")
 
-solver.run(p=[0.5, 4.2], initial_guess=[3, 5, 2, 1, 4], initial_penalty=100)
+# Precond    NonPrecond
+# 125/16     273/14

--- a/open-codegen/opengen/main.py
+++ b/open-codegen/opengen/main.py
@@ -16,9 +16,9 @@ for i in range(nu):
 
 
 c_f1 = cs.vertcat(p[0] * u[0] - u[1], p[1]*u[2] - u[3] + 0.1)
-c_f2 = cs.vertcat((u[2]+1)**2 - 8*u[4], 2*cs.sin(u[4] + 1), 5*cs.sin(u[3] + 1))
+c_f2 = cs.vertcat((u[2]+1)**2 - 8*u[4], 5*cs.sin(u[3] + 1))
 
-bounds = og.constraints.Halfspace([1., 2.5, 1., 5., 2.], 10.39)
+bounds = og.constraints.Halfspace([1, 1, 1, 1, 1], 100)
 problem = og.builder.Problem(u, p, phi) \
     .with_penalty_constraints(c_f2)\
     .with_aug_lagrangian_constraints(c_f1, og.constraints.Zero())\
@@ -51,6 +51,8 @@ print(" ")
 print(f"solution = {result.solution}")
 print(f"time = {result.solve_time_ms} ms")
 print(f"penalty = {result.penalty}")
+print(f"infeasibility f1 = {result.f1_infeasibility}")
+print(f"infeasibility f2 = {result.f2_norm}")
 print(f"status = {result.exit_status}")
 
-solver.run(p=[3.5, 7.8], initial_guess=[1, 2, 3, 4, 5], initial_penalty=100)
+solver.run(p=[0.5, 4.2], initial_guess=[3, 5, 2, 1, 4], initial_penalty=100)

--- a/open-codegen/opengen/main.py
+++ b/open-codegen/opengen/main.py
@@ -52,3 +52,5 @@ print(f"solution = {result.solution}")
 print(f"time = {result.solve_time_ms} ms")
 print(f"penalty = {result.penalty}")
 print(f"status = {result.exit_status}")
+
+solver.run(p=[3.5, 7.8], initial_guess=[1, 2, 3, 4, 5], initial_penalty=100)

--- a/open-codegen/opengen/main.py
+++ b/open-codegen/opengen/main.py
@@ -11,16 +11,15 @@ nu, np = 5, 2
 u = cs.SX.sym("u", nu)  # decision variable (nu = 5)
 p = cs.SX.sym("p", 2)  # parameter (np = 2)
 phi = og.functions.rosenbrock(u, p)
-for i in range(nu):
-    phi = phi + p[1] * cs.sin(u[i])
 
-c_f1 = cs.vertcat(p[0] * u[0] - u[1], p[1]*u[2] - u[3] + 0.1)
+# c_f1 = cs.vertcat(p[0] * u[0] - u[1], p[1]*u[2] - u[3] + 0.1)
+c_f2 = cs.vertcat(0.2 + 1.5 * u[0] - u[1], u[2] - u[3] - 0.1)
 
-bounds = og.constraints.Halfspace([1, 1, 1, 1, 1], 100)
+bounds = og.constraints.Ball2(None, 1.5)
 problem = og.builder.Problem(u, p, phi) \
-    .with_aug_lagrangian_constraints(c_f1, og.constraints.Zero())\
+    .with_penalty_constraints(c_f2)\
     .with_constraints(bounds)
-meta = og.config.OptimizerMeta() \
+meta = og.config.OptimizerMeta()\
     .with_optimizer_name(optimizer_name)
 
 build_config = og.config.BuildConfiguration() \
@@ -30,8 +29,8 @@ build_config = og.config.BuildConfiguration() \
 solver_cfg = og.config.SolverConfiguration() \
     .with_tolerance(1e-6) \
     .with_max_inner_iterations(1000) \
-    .with_max_outer_iterations(20) \
-    .with_penalty_weight_update_factor(1.3) \
+    .with_max_outer_iterations(30) \
+    .with_penalty_weight_update_factor(1.5) \
     .with_preconditioning(True)
 
 builder = og.builder.OpEnOptimizerBuilder(problem,
@@ -55,5 +54,11 @@ print(f"status = {result.exit_status}")
 print(f"inner = {result.num_inner_iterations}")
 print(f"outer = {result.num_outer_iterations}")
 
-# Precond    NonPrecond
-# 125/16     273/14
+# Preconditioned    Non-preconditioned
+# -------------------------------------
+# 23/3              244/26
+
+# Solutions:
+#
+# [-0.06168156776090604, 0.10745271293967644, 0.11363970229300129, 0.013666212246169969, 0.00018549750799884656]
+# [-0.06168061635750967, 0.10744096043712821, 0.11361445307465148, 0.013640838407880301, 0.00019045750968868237]

--- a/open-codegen/opengen/tcp/optimizer_tcp_manager.py
+++ b/open-codegen/opengen/tcp/optimizer_tcp_manager.py
@@ -93,7 +93,11 @@ class OptimizerTcpManager:
         ip = tcp_data['tcp']['ip']
         port = tcp_data['tcp']['port']
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-        s.connect((ip, port))
+        try:
+            s.connect((ip, port))
+        except ConnectionRefusedError as err:
+            s.close()
+            raise err
         return s
 
     def __send_receive_data(self, text_to_send, buffer_size=512, max_data_size=1048576):
@@ -126,8 +130,10 @@ class OptimizerTcpManager:
         tcp_data = self.__optimizer_details
         ip = tcp_data['tcp']['ip']
         port = tcp_data['tcp']['port']
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-        return 0 == s.connect_ex((ip, port))
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0) as s:
+            result = 0 == s.connect_ex((ip, port))
+
+        return result
 
     @property
     def details(self):

--- a/open-codegen/opengen/templates/icasadi/icasadi_lib.rs
+++ b/open-codegen/opengen/templates/icasadi/icasadi_lib.rs
@@ -54,13 +54,22 @@ extern "C" {
         arg: *const *const c_double,
         ipnlt: *mut *mut c_double,
     ) -> c_int;
-
+    fn get_w_cost_{{ meta.optimizer_name }}() -> c_double;
 } // END of extern C
 
 
 // -----------------------------------------------------------
 //  *MAIN* API Functions in Rust
 // -----------------------------------------------------------
+
+///
+/// Getter function for w_cost
+///
+pub fn get_w_cost() -> f64 {
+    unsafe {
+        get_w_cost_{{ meta.optimizer_name }}() as f64
+    }
+}
 
 ///
 /// Initialise the interface by setting all preconditioning parameters to 1

--- a/open-codegen/opengen/templates/icasadi/interface.c
+++ b/open-codegen/opengen/templates/icasadi/interface.c
@@ -367,6 +367,13 @@ static casadi_real **result_space_init_penalty = NULL;
 static casadi_real uxip_space[N_UXIPW_{{ meta.optimizer_name | upper}}];
 
 /**
+ * Return scaling factor of cost function (getter)
+ */
+casadi_real get_w_cost_{{ meta.optimizer_name }}(void) {
+    return uxip_space[IDX_WC_{{ meta.optimizer_name | upper}}];
+}
+
+/**
  * This function should be called upon initialisation. The sets all w's to 1.
  */
 void init_interface_{{ meta.optimizer_name }}(void) {

--- a/open-codegen/opengen/templates/optimizer.rs
+++ b/open-codegen/opengen/templates/optimizer.rs
@@ -328,6 +328,10 @@ pub fn solve(
     y0: &Option<Vec<f64>>,
     c0: &Option<f64>,
 ) -> Result<AlmOptimizerStatus, SolverError> {
+
+    assert_eq!(p.len(), {{meta.optimizer_name|upper}}_NUM_PARAMETERS, "Wrong number of parameters (p)");
+    assert_eq!(u.len(), {{meta.optimizer_name|upper}}_NUM_DECISION_VARIABLES, "Wrong number of decision variables (u)");
+
     // Start by initialising the optimiser interface (e.g., set w=1)
     icasadi_{{meta.optimizer_name}}::init_{{ meta.optimizer_name }}();
 
@@ -340,9 +344,6 @@ pub fn solve(
         // Compute initial penalty
         icasadi_{{meta.optimizer_name}}::initial_penalty(u, p, & mut rho_init);
     }
-
-    assert_eq!(p.len(), {{meta.optimizer_name|upper}}_NUM_PARAMETERS, "Wrong number of parameters (p)");
-    assert_eq!(u.len(), {{meta.optimizer_name|upper}}_NUM_DECISION_VARIABLES, "Wrong number of decision variables (u)");
 
     let psi = |u: &[f64], xi: &[f64], cost: &mut f64| -> Result<(), SolverError> {
         icasadi_{{meta.optimizer_name}}::cost(u, xi, p, cost);

--- a/open-codegen/opengen/templates/optimizer.rs
+++ b/open-codegen/opengen/templates/optimizer.rs
@@ -329,6 +329,16 @@ pub fn solve(
     // Start by initialising the optimiser interface (e.g., set w=1)
     icasadi_{{meta.optimizer_name}}::init_{{ meta.optimizer_name }}();
 
+    // Compute the preconditioning parameters (w's)
+    // The scaling parameters will be stored internally in `interface.c`
+    icasadi_{{meta.optimizer_name}}::precondition(u, p);
+
+    // Compute initial penalty
+    let mut rho_init : f64 = 1.0;
+    icasadi_{{meta.optimizer_name}}::initial_penalty(u, p, &mut rho_init);
+
+
+
     assert_eq!(p.len(), {{meta.optimizer_name|upper}}_NUM_PARAMETERS, "Wrong number of parameters (p)");
     assert_eq!(u.len(), {{meta.optimizer_name|upper}}_NUM_DECISION_VARIABLES, "Wrong number of decision variables (u)");
 

--- a/open-codegen/opengen/templates/optimizer.rs
+++ b/open-codegen/opengen/templates/optimizer.rs
@@ -335,10 +335,10 @@ pub fn solve(
     if DO_PRECONDITIONING {
         // Compute the preconditioning parameters (w's)
         // The scaling parameters will be stored internally in `interface.c`
-        icasadi_rosenbrock::precondition(u, p);
+        icasadi_{{meta.optimizer_name}}::precondition(u, p);
 
         // Compute initial penalty
-        icasadi_rosenbrock::initial_penalty(u, p, & mut rho_init);
+        icasadi_{{meta.optimizer_name}}::initial_penalty(u, p, & mut rho_init);
     }
 
     assert_eq!(p.len(), {{meta.optimizer_name|upper}}_NUM_PARAMETERS, "Wrong number of parameters (p)");

--- a/open-codegen/opengen/templates/optimizer.rs
+++ b/open-codegen/opengen/templates/optimizer.rs
@@ -326,6 +326,8 @@ pub fn solve(
     y0: &Option<Vec<f64>>,
     c0: &Option<f64>,
 ) -> Result<AlmOptimizerStatus, SolverError> {
+    // Start by initialising the optimiser interface (e.g., set w=1)
+    icasadi_{{meta.optimizer_name}}::init_{{ meta.optimizer_name }}();
 
     assert_eq!(p.len(), {{meta.optimizer_name|upper}}_NUM_PARAMETERS, "Wrong number of parameters (p)");
     assert_eq!(u.len(), {{meta.optimizer_name|upper}}_NUM_DECISION_VARIABLES, "Wrong number of decision variables (u)");

--- a/open-codegen/opengen/templates/optimizer.rs
+++ b/open-codegen/opengen/templates/optimizer.rs
@@ -321,6 +321,17 @@ pub fn initialize_solver() -> AlmCache {
 
 
 /// Solver interface
+///
+/// ## Arguments
+/// - `p`: static parameter vector of the optimization problem
+/// - `alm_cache`: Instance of AlmCache
+/// - `u`: Initial guess
+/// - `y0` (optional) initial vector of Lagrange multipliers
+/// - `c0` (optional) initial penalty
+///
+/// ## Returns
+/// This function returns either an instance of AlmOptimizerStatus with information about the
+/// solution, or a SolverError object if something goes wrong
 pub fn solve(
     p: &[f64],
     alm_cache: &mut AlmCache,

--- a/open-codegen/opengen/test/test.py
+++ b/open-codegen/opengen/test/test.py
@@ -31,7 +31,8 @@ class RustBuildTestCase(unittest.TestCase):
             .with_max_duration_micros(1e8) \
             .with_max_outer_iterations(50) \
             .with_sufficient_decrease_coefficient(0.05) \
-            .with_cbfgs_parameters(1.5, 1e-10, 1e-12)
+            .with_cbfgs_parameters(1.5, 1e-10, 1e-12) \
+            .with_preconditioning(True)
         return solver_config
 
     @classmethod
@@ -293,7 +294,7 @@ class RustBuildTestCase(unittest.TestCase):
 
     def test_start_multiple_servers(self):
         all_managers = []
-        for i in range(50):
+        for i in range(10):
             all_managers += [og.tcp.OptimizerTcpManager(
                 optimizer_path=RustBuildTestCase.TEST_DIR + '/only_f1',
                 ip='0.0.0.0',

--- a/open-codegen/opengen/test/test.py
+++ b/open-codegen/opengen/test/test.py
@@ -226,15 +226,14 @@ class RustBuildTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # cls.setUpPythonBindings()
-        # cls.setUpRosPackageGeneration()
-        # cls.setUpOnlyF1()
-        # cls.setUpOnlyF2()
-        # cls.setUpOnlyF2(is_preconditioned=True)
-        # cls.setUpPlain()
-        # cls.setUpOnlyParametricF2()
-        # cls.setUpHalfspace()
-        pass
+        cls.setUpPythonBindings()
+        cls.setUpRosPackageGeneration()
+        cls.setUpOnlyF1()
+        cls.setUpOnlyF2()
+        cls.setUpOnlyF2(is_preconditioned=True)
+        cls.setUpPlain()
+        cls.setUpOnlyParametricF2()
+        cls.setUpHalfspace()
 
     def test_python_bindings(self):
         import sys

--- a/src/alm/alm_optimizer_status.rs
+++ b/src/alm/alm_optimizer_status.rs
@@ -202,7 +202,7 @@ impl AlmOptimizerStatus {
     }
 
     /// Update PM infeasibility
-    pub fn update_f2_norm(&mut self, new_pm_infeasibility: f64){
+    pub fn update_f2_norm(&mut self, new_pm_infeasibility: f64) {
         self.f2_norm = new_pm_infeasibility;
     }
 

--- a/src/alm/alm_optimizer_status.rs
+++ b/src/alm/alm_optimizer_status.rs
@@ -186,6 +186,26 @@ impl AlmOptimizerStatus {
         self.cost = cost;
         self
     }
+
+    // -------------------------------------------------
+    // Update Methods
+    // -------------------------------------------------
+
+    /// Update cost (to be used when the cost needs to be scaled as a result of preconditioning)
+    pub fn update_cost(&mut self, new_cost: f64) {
+        self.cost = new_cost;
+    }
+
+    /// Update ALM infeasibility
+    pub fn update_f1_infeasibility(&mut self, new_alm_infeasibility: f64) {
+        self.delta_y_norm = new_alm_infeasibility;
+    }
+
+    /// Update PM infeasibility
+    pub fn update_f2_norm(&mut self, new_pm_infeasibility: f64){
+        self.f2_norm = new_pm_infeasibility;
+    }
+
     // -------------------------------------------------
     // Getter Methods
     // -------------------------------------------------


### PR DESCRIPTION
## Main Changes

Essentially, this PR finalises most of the tasks involved in #292.

### In `optimizer.rs`:
- initialise optimiser interface
- compute scaling parameters and initial penalty
- scale auto-generated functions
- undo the scaling to return the actual optimal cost

### In `optimizer_builder.py`:
- Functions `psi`, `grad_psi`, `F1` and `F2` become functions of `θ=(p, w)` instead of just `p`

### In `interface.c`:
- Introduced a function to export the scaling parameter `w_cost`

### In `alm_optimizer_status.rs` 
- Included functions that allow to update the cost and the infeasibilities

### Other
- Fix issue with open sockets not getting closed
- Fix issue in `Halfspace` (missing `float`)
- Testing

## Associated Issues

- Addresses #106
- Addresses #107


## TODOs

- [x] Documentation 
- [x] All tests must pass
- [x] Update OpEn `CHANGELOG` (Rust)
- [x] ~Update webpage documentation~ (will do later)
