### PR TITLE
build() to return dictionary with details

### DIFF
--- a/open-codegen/CHANGELOG.md
+++ b/open-codegen/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Note: This is the Changelog file of `opengen` - the Python interface of OpEn
 
 
-<!-- 
-  UNRELEASED!
-  0.7.1 has not been released yet
-  -->
-## [0.7.1] - Unreleased
+
+## [0.7.1] - 2022-02-14
+
+### Added
+
+* Method `.build` returns a dictionary with information that can assist debugging
+
 
 ### Changed
 

--- a/open-codegen/opengen/builder/optimizer_builder.py
+++ b/open-codegen/opengen/builder/optimizer_builder.py
@@ -792,11 +792,25 @@ class OpEnOptimizerBuilder:
         with open(cbind_makefile_target_path, "w") as fh:
             fh.write(cbind_makefile_output_template)
 
+    def __info(self):
+        info = {
+            "meta": self.__meta.to_dict(),
+            "problem": self.__problem.to_dict(),
+            "build_config": self.__build_config.to_dict(),
+            "solver_config": self.__solver_config.to_dict(),
+            "paths": {
+                "target": self.__target_dir(),
+            }
+        }
+        return info
+
     def build(self):
         """Generate code and build project
 
         :raises Exception: if the build process fails
         :raises Exception: if there some parameters have wrong, inadmissible or incompatible values
+
+        :returns: Dictionary with information that can be used for debugging
 
         """
         self.__initialize()                      # initialize default value (if not provided)
@@ -846,3 +860,5 @@ class OpEnOptimizerBuilder:
                 self.__build_config,
                 self.__solver_config)
             ros_builder.build()
+
+        return self.__info()

--- a/open-codegen/opengen/builder/problem.py
+++ b/open-codegen/opengen/builder/problem.py
@@ -219,3 +219,11 @@ class Problem:
         This is a CasADi symbol (SX or MX)
         """
         return self.__w2
+
+    def to_dict(self):
+        return {
+            "dim_decision_variables": self.dim_decision_variables(),
+            "dim_parameters": self.dim_parameters(),
+            "dim_constraints_penalty": self.dim_constraints_penalty(),
+            "dim_constraints_aug_lagrangian": self.dim_constraints_aug_lagrangian()
+        }

--- a/open-codegen/opengen/builder/ros_builder.py
+++ b/open-codegen/opengen/builder/ros_builder.py
@@ -62,7 +62,6 @@ class RosBuilder:
     def __generate_ros_dir_structure(self):
         self.__logger.info("Generating directory structure")
         target_ros_dir = self.__ros_target_dir()
-        print(f"TARGET ROS DIR: {target_ros_dir}")
         make_dir_if_not_exists(target_ros_dir)
         make_dir_if_not_exists(os.path.abspath(
             os.path.join(target_ros_dir, 'include')))
@@ -107,7 +106,6 @@ class RosBuilder:
                 target_ros_dir, 'include', header_file_name))
         original_include_file = os.path.abspath(
             os.path.join(self.__target_dir(), header_file_name))
-        print(original_include_file)
         shutil.copyfile(original_include_file, target_include_filename)
 
         # 2. --- copy library file

--- a/open-codegen/opengen/builder/ros_builder.py
+++ b/open-codegen/opengen/builder/ros_builder.py
@@ -62,6 +62,7 @@ class RosBuilder:
     def __generate_ros_dir_structure(self):
         self.__logger.info("Generating directory structure")
         target_ros_dir = self.__ros_target_dir()
+        print(f"TARGET ROS DIR: {target_ros_dir}")
         make_dir_if_not_exists(target_ros_dir)
         make_dir_if_not_exists(os.path.abspath(
             os.path.join(target_ros_dir, 'include')))
@@ -106,6 +107,7 @@ class RosBuilder:
                 target_ros_dir, 'include', header_file_name))
         original_include_file = os.path.abspath(
             os.path.join(self.__target_dir(), header_file_name))
+        print(original_include_file)
         shutil.copyfile(original_include_file, target_include_filename)
 
         # 2. --- copy library file

--- a/open-codegen/opengen/config/build_config.py
+++ b/open-codegen/opengen/config/build_config.py
@@ -298,4 +298,6 @@ class BuildConfiguration:
         }
         if self.__tcp_interface_config is not None:
             build_dict["tcp_interface_config"] = self.__tcp_interface_config.to_dict()
+        if self.__ros_config is not None:
+            build_dict["ros_config"] = self.__ros_config.to_dict()
         return build_dict

--- a/open-codegen/opengen/config/build_config.py
+++ b/open-codegen/opengen/config/build_config.py
@@ -285,3 +285,17 @@ class BuildConfiguration:
         """
         self.__allocator = allocator
         return self
+
+    def to_dict(self):
+        build_dict = {
+            "target_system": self.__target_system,
+            "build_mode": self.__build_mode,
+            "rebuild": self.__rebuild,
+            "build_directory": self.__build_dir,
+            "open_version": self.__open_version,
+            "build_c_bindings": self.__build_c_bindings,
+            "build_python_bindings": self.__build_python_bindings,
+        }
+        if self.__tcp_interface_config is not None:
+            build_dict["tcp_interface_config"] = self.__tcp_interface_config.to_dict()
+        return build_dict

--- a/open-codegen/opengen/config/meta.py
+++ b/open-codegen/opengen/config/meta.py
@@ -168,3 +168,11 @@ class OptimizerMeta:
         :meta private:
         """
         return self.__optimizer_licence
+
+    def to_dict(self):
+        return {
+            "name": self.__optimizer_name,
+            "version": self.__optimizer_version,
+            "author": self.__optimizer_author_list,
+            "licence": self.__optimizer_licence
+        }

--- a/open-codegen/opengen/config/ros_config.py
+++ b/open-codegen/opengen/config/ros_config.py
@@ -193,3 +193,15 @@ class RosConfiguration:
         """
         self.__subscriber_subtopic = subscriber_subtopic
         return self
+
+    def to_dict(self):
+        return {
+            "package_name": self.__package_name,
+            "node_name": self.__node_name,
+            "description": self.__description,
+            "rate": self.__rate,
+            "result_topic_queue_size": self.__result_topic_queue_size,
+            "params_topic_queue_size": self.__params_topic_queue_size,
+            "publisher_subtopic": self.__publisher_subtopic,
+            "subscriber_subtopic": self.__subscriber_subtopic
+        }

--- a/open-codegen/opengen/config/solver_config.py
+++ b/open-codegen/opengen/config/solver_config.py
@@ -320,3 +320,22 @@ class SolverConfiguration:
         """
         self.__do_preconditioning = do_preconditioning
         return self
+
+    def to_dict(self):
+        return {
+            "tolerance": self.__tolerance,
+            "initial_tolerance": self.__initial_tolerance,
+            "lbfgs_memory": self.__lbfgs_memory,
+            "max_inner_iterations": self.__max_inner_iterations,
+            "max_outer_iterations": self.__max_outer_iterations,
+            "constraints_tolerance": self.__constraints_tolerance,
+            "initial_penalty": self.__initial_penalty,
+            "penalty_weight_update_factor": self.__penalty_weight_update_factor,
+            "max_duration_micros": self.__max_duration_micros,
+            "inner_tolerance_update_factor": self.__inner_tolerance_update_factor,
+            "sufficient_decrease_coefficient": self.__sufficient_decrease_coefficient,
+            "cbfgs_alpha": self.__cbfgs_alpha,
+            "cbfgs_epsilon": self.__cbfgs_epsilon,
+            "cbfgs_sy_epsilon": self.__cbfgs_sy_epsilon,
+            "do_preconditioning": self.__do_preconditioning
+        }

--- a/open-codegen/opengen/config/tcp_server_config.py
+++ b/open-codegen/opengen/config/tcp_server_config.py
@@ -35,3 +35,9 @@ class TcpServerConfiguration:
         :return: TCP server port
         """
         return self.__bind_port
+
+    def to_dict(self):
+        return {
+            "ip": self.__bind_ip,
+            "port": self.__bind_port
+        }


### PR DESCRIPTION
## Main Changes

- Method `build()` returns a dictionary with various information that can assist debuggining 
- Better error reporting in Rust (TCP server)


## Associated Issues

- Closes #316


## TODOs

- [x] Documentation 
- [x] Update `CHANGELOG`(s)
- [x] ~Update webpage documentation~
- [x] Bump versions (in `CHANGELOG`, `Cargo.toml` and `VERSION`)
