### PR TITLE
Kylc/fix alm docs typo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest]
+        os: [ubuntu-20.04, ubuntu-latest]
     env:
       DO_DOCKER: 0
     steps:

--- a/docs/openrust-alm.md
+++ b/docs/openrust-alm.md
@@ -150,7 +150,7 @@ pub fn df(u: &[f64], grad: &mut [f64]) -> Result<(), SolverError> {
 Suppose we need to impose the constraint $F_1(u) \in C$, where $C=\\{z\in\mathbb{R}^2: \Vert{}z{}\Vert \leq 1\\}$
 and $F_1$ is the mapping 
 $$
-F_1(u)=\begin{bmatrix}2u_1 + u_1 + 0.5 \\\\ u_1+3u_2\end{bmatrix}
+F_1(u)=\begin{bmatrix}2u_1 + u_3 + 0.5 \\\\ u_1+3u_2\end{bmatrix}
 $$
 
 ```rust


### PR DESCRIPTION
## Main Changes

- Typo corrected by @kylc
- Updates in CI (`ubuntu-18.04` is not supported any more, so I changed it to `ubuntu-20.04`)