### PR TITLE
Spherical constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Note: This is the main Changelog file for the Rust solver. The Changelog file fo
 
 
 <!-- ---------------------
+      v0.7.8
+     --------------------- -->
+## [v0.7.7] - 2023-10-27
+
+### Added
+
+- New constraint: sphere of Euclidean norm
+
+<!-- ---------------------
       v0.7.7
      --------------------- -->
 ## [v0.7.7] - 2023-01-17
@@ -247,6 +256,7 @@ This is a breaking API change.
      --------------------- -->
 
 <!-- Releases -->
+[v0.7.8]: https://github.com/alphaville/optimization-engine/compare/v0.7.7...v0.7.8 
 [v0.7.7]: https://github.com/alphaville/optimization-engine/compare/v0.7.6...v0.7.7 
 [v0.7.6]: https://github.com/alphaville/optimization-engine/compare/v0.7.5...v0.7.6 
 [v0.7.5]: https://github.com/alphaville/optimization-engine/compare/v0.7.4...v0.7.5 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ Note: This is the main Changelog file for the Rust solver. The Changelog file fo
 
 
 <!-- ---------------------
-      v0.7.8
+      v0.8.0
      --------------------- -->
-## [v0.7.8] - 2023-10-27
+## [v0.8.1] - 2023-10-27
 
 ### Added
 
@@ -256,7 +256,7 @@ This is a breaking API change.
      --------------------- -->
 
 <!-- Releases -->
-[v0.7.8]: https://github.com/alphaville/optimization-engine/compare/v0.7.7...v0.7.8 
+[v0.7.8]: https://github.com/alphaville/optimization-engine/compare/v0.7.7...v0.8.0
 [v0.7.7]: https://github.com/alphaville/optimization-engine/compare/v0.7.6...v0.7.7 
 [v0.7.6]: https://github.com/alphaville/optimization-engine/compare/v0.7.5...v0.7.6 
 [v0.7.5]: https://github.com/alphaville/optimization-engine/compare/v0.7.4...v0.7.5 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ homepage = "https://alphaville.github.io/optimization-engine/"
 repository = "https://github.com/alphaville/optimization-engine"
 
 # Version of this crate (SemVer)
-version = "0.7.8"
+version = "0.8.0"
 
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ homepage = "https://alphaville.github.io/optimization-engine/"
 repository = "https://github.com/alphaville/optimization-engine"
 
 # Version of this crate (SemVer)
-version = "0.7.7"
+version = "0.7.8"
 
 edition = "2018"
 

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -19,6 +19,7 @@ mod no_constraints;
 mod rectangle;
 mod simplex;
 mod soc;
+mod sphere2;
 mod zero;
 
 pub use ball1::Ball1;
@@ -32,6 +33,7 @@ pub use no_constraints::NoConstraints;
 pub use rectangle::Rectangle;
 pub use simplex::Simplex;
 pub use soc::SecondOrderCone;
+pub use sphere2::Sphere2;
 pub use zero::Zero;
 
 /// A set which can be used as a constraint

--- a/src/constraints/sphere2.rs
+++ b/src/constraints/sphere2.rs
@@ -1,8 +1,8 @@
 use super::Constraint;
 
 #[derive(Copy, Clone)]
-/// A Euclidean sphere, that is, a set given by $B_2^r = \\{x \in \mathbb{R}^n {}:{} \Vert{}x{}\Vert = r\\}$
-/// or a Euclidean sphere centered at a point $x_c$, that is, $B_2^{x_c, r} = \\{x \in \mathbb{R}^n {}:{} \Vert{}x-x_c{}\Vert = r\\}$
+/// A Euclidean sphere, that is, a set given by $S_2^r = \\{x \in \mathbb{R}^n {}:{} \Vert{}x{}\Vert = r\\}$
+/// or a Euclidean sphere centered at a point $x_c$, that is, $S_2^{x_c, r} = \\{x \in \mathbb{R}^n {}:{} \Vert{}x-x_c{}\Vert = r\\}$
 pub struct Sphere2<'a> {
     center: Option<&'a [f64]>,
     radius: f64,
@@ -18,13 +18,16 @@ impl<'a> Sphere2<'a> {
 }
 
 impl<'a> Constraint for Sphere2<'a> {
-    /// Projection onto the set, that is,
+    /// Projection onto the sphere, $S_{r, c}$ with radius $r$ and center $c$.
+    /// If $x\neq c$, the projection is uniquely defined by
     ///
     /// $$
-    /// \Pi_C(v) = \mathrm{argmin}_{z\in C}\Vert{}z-v{}\Vert
+    /// P_{S_{r, c}}(x) = c + r\frac{x-c}{\Vert{}x-c\Vert_2},
     /// $$
     ///
-    ///
+    /// but for $x=c$, the projection is multi-valued. In particular, let
+    /// $y = P_{S_{r, c}}(c)$. Then $y_1 = c_1 + r$ and $y_i = c_i$ for
+    /// $i=2,\ldots, n$.
     ///
     /// ## Arguments
     ///
@@ -53,6 +56,8 @@ impl<'a> Constraint for Sphere2<'a> {
         }
     }
 
+    /// Returns false (the sphere is not a convex set)
+    ///
     fn is_convex(&self) -> bool {
         false
     }

--- a/src/constraints/sphere2.rs
+++ b/src/constraints/sphere2.rs
@@ -1,0 +1,42 @@
+use super::Constraint;
+
+#[derive(Copy, Clone)]
+/// A Euclidean sphere, that is, a set given by $B_2^r = \\{x \in \mathbb{R}^n {}:{} \Vert{}x{}\Vert = r\\}$
+/// or a Euclidean sphere centered at a point $x_c$, that is, $B_2^{x_c, r} = \\{x \in \mathbb{R}^n {}:{} \Vert{}x-x_c{}\Vert = r\\}$
+pub struct Sphere2<'a> {
+    center: Option<&'a [f64]>,
+    radius: f64,
+}
+
+impl<'a> Sphere2<'a> {
+    /// Construct a new Euclidean sphere with given center and radius
+    /// If no `center` is given, then it is assumed to be in the origin
+    pub fn new(center: Option<&'a [f64]>, radius: f64) -> Self {
+        assert!(radius > 0.0);
+        Sphere2 { center, radius }
+    }
+}
+
+impl<'a> Constraint for Sphere2<'a> {
+    fn project(&self, x: &mut [f64]) {
+        if let Some(center) = &self.center {
+            let mut norm_difference = 0.0;
+            x.iter().zip(center.iter()).for_each(|(a, b)| {
+                let diff_ = *a - *b;
+                norm_difference += diff_ * diff_
+            });
+            norm_difference = norm_difference.sqrt();
+            x.iter_mut().zip(center.iter()).for_each(|(x, c)| {
+                *x = *c + (*x - *c) / norm_difference;
+            });
+        } else {
+            let norm_x = crate::matrix_operations::norm2(x);
+            let norm_over_radius = norm_x / self.radius;
+            x.iter_mut().for_each(|x_| *x_ /= norm_over_radius);
+        }
+    }
+
+    fn is_convex(&self) -> bool {
+        true
+    }
+}

--- a/src/constraints/sphere2.rs
+++ b/src/constraints/sphere2.rs
@@ -21,13 +21,13 @@ impl<'a> Constraint for Sphere2<'a> {
     fn project(&self, x: &mut [f64]) {
         if let Some(center) = &self.center {
             let mut norm_difference = 0.0;
-            x.iter().zip(center.iter()).for_each(|(a, b)| {
-                let diff_ = *a - *b;
+            x.iter().zip(center.iter()).for_each(|(xi, ci)| {
+                let diff_ = *xi - *ci;
                 norm_difference += diff_ * diff_
             });
             norm_difference = norm_difference.sqrt();
             x.iter_mut().zip(center.iter()).for_each(|(x, c)| {
-                *x = *c + (*x - *c) / norm_difference;
+                *x = *c + self.radius * (*x - *c) / norm_difference;
             });
         } else {
             let norm_x = crate::matrix_operations::norm2(x);
@@ -37,6 +37,6 @@ impl<'a> Constraint for Sphere2<'a> {
     }
 
     fn is_convex(&self) -> bool {
-        true
+        false
     }
 }

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -778,10 +778,40 @@ fn t_sphere2_no_center() {
 }
 
 #[test]
+fn t_sphere2_no_center_projection_of_zero() {
+    let radius = 0.9;
+    let mut x = [0.0, 0.0];
+    let unit_sphere = Sphere2::new(None, radius);
+    unit_sphere.project(&mut x);
+    let norm_result = crate::matrix_operations::norm2(&x);
+    unit_test_utils::assert_nearly_equal(radius, norm_result, 1e-10, 1e-12, "norm_out is not 1.0");
+}
+
+#[test]
 fn t_sphere2_center() {
     let radius = 1.3;
     let center = [-3.0, 5.0];
     let mut x = [1.0, 1.0];
+    let unit_sphere = Sphere2::new(Some(&center), radius);
+
+    unit_sphere.project(&mut x);
+    let mut x_minus_c = [0.0; 2];
+    x.iter()
+        .zip(center.iter())
+        .zip(x_minus_c.iter_mut())
+        .for_each(|((a, b), c)| {
+            *c = a - b;
+        });
+
+    let norm_out = crate::matrix_operations::norm2(&x_minus_c);
+    unit_test_utils::assert_nearly_equal(radius, norm_out, 1e-10, 1e-12, "norm_out is not 1.0");
+}
+
+#[test]
+fn t_sphere2_center_projection_of_center() {
+    let radius = 1.3;
+    let center = [-3.0, 5.0];
+    let mut x = [-3.0, 5.0];
     let unit_sphere = Sphere2::new(Some(&center), radius);
 
     unit_sphere.project(&mut x);

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -764,6 +764,20 @@ fn t_ball1_random_optimality_conditions_centered() {
 }
 
 #[test]
+fn t_sphere2_no_center() {
+    let radius = 1.0;
+    let mut x_out = [1.0, 1.0];
+    let mut x_in = [1.0, 1.0];
+    let unit_sphere = Sphere2::new(None, radius);
+    unit_sphere.project(&mut x_out);
+    unit_sphere.project(&mut x_in);
+    let norm_out = crate::matrix_operations::norm2(&x_out);
+    let norm_in = crate::matrix_operations::norm2(&x_in);
+    unit_test_utils::assert_nearly_equal(1.0, norm_out, 1e-10, 1e-12, "norm_out is not 1.0");
+    unit_test_utils::assert_nearly_equal(1.0, norm_in, 1e-10, 1e-12, "norm_in is not 1.0");
+}
+
+#[test]
 #[should_panic]
 fn t_ball1_alpha_negative() {
     let _ = Ball1::new(None, -1.);

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -773,8 +773,28 @@ fn t_sphere2_no_center() {
     unit_sphere.project(&mut x_in);
     let norm_out = crate::matrix_operations::norm2(&x_out);
     let norm_in = crate::matrix_operations::norm2(&x_in);
-    unit_test_utils::assert_nearly_equal(1.0, norm_out, 1e-10, 1e-12, "norm_out is not 1.0");
-    unit_test_utils::assert_nearly_equal(1.0, norm_in, 1e-10, 1e-12, "norm_in is not 1.0");
+    unit_test_utils::assert_nearly_equal(radius, norm_out, 1e-10, 1e-12, "norm_out is not 1.0");
+    unit_test_utils::assert_nearly_equal(radius, norm_in, 1e-10, 1e-12, "norm_in is not 1.0");
+}
+
+#[test]
+fn t_sphere2_center() {
+    let radius = 1.0;
+    let center = [-3.0, 5.0];
+    let mut x = [1.0, 1.0];
+    let unit_sphere = Sphere2::new(Some(&center), radius);
+
+    unit_sphere.project(&mut x);
+    let mut x_minus_c = [0.0; 2];
+    x.iter()
+        .zip(center.iter())
+        .zip(x_minus_c.iter_mut())
+        .for_each(|((a, b), c)| {
+            *c = a - b;
+        });
+
+    let norm_out = crate::matrix_operations::norm2(&x_minus_c);
+    unit_test_utils::assert_nearly_equal(radius, norm_out, 1e-10, 1e-12, "norm_out is not 1.0");
 }
 
 #[test]

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -765,9 +765,9 @@ fn t_ball1_random_optimality_conditions_centered() {
 
 #[test]
 fn t_sphere2_no_center() {
-    let radius = 1.0;
+    let radius = 0.9;
     let mut x_out = [1.0, 1.0];
-    let mut x_in = [1.0, 1.0];
+    let mut x_in = [-0.3, -0.2];
     let unit_sphere = Sphere2::new(None, radius);
     unit_sphere.project(&mut x_out);
     unit_sphere.project(&mut x_in);
@@ -779,7 +779,7 @@ fn t_sphere2_no_center() {
 
 #[test]
 fn t_sphere2_center() {
-    let radius = 1.0;
+    let radius = 1.3;
     let center = [-3.0, 5.0];
     let mut x = [1.0, 1.0];
     let unit_sphere = Sphere2::new(Some(&center), radius);


### PR DESCRIPTION
## Main Changes

- Implementation of `sphere2.rs` in Rust: a constraint of the form $\\|x\\| = r$ or $\\|x-c\\| = r$


## Associated Issues

None


## TODOs

- [x] Documentation 
- [x] All tests must pass
- [x] Update `CHANGELOG`(s)
- [ ] Update webpage documentation
- [x] Bump versions (in `CHANGELOG`, `Cargo.toml` and `VERSION`)
