### PR TITLE
Projection on affine space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Note: This is the main Changelog file for the Rust solver. The Changelog file fo
 <!-- ---------------------
       Not released
      --------------------- -->
-## Unreleased
+## [v0.9.0] - Unreleased
 
 ### Added
 
@@ -279,6 +279,7 @@ This is a breaking API change.
      --------------------- -->
 
 <!-- Releases -->
+[v0.9.0]: https://github.com/alphaville/optimization-engine/compare/v0.8.1...v0.9.0
 [v0.8.1]: https://github.com/alphaville/optimization-engine/compare/v0.8.0...v0.8.1
 [v0.8.0]: https://github.com/alphaville/optimization-engine/compare/v0.7.7...v0.8.0
 [v0.7.7]: https://github.com/alphaville/optimization-engine/compare/v0.7.6...v0.7.7 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Note: This is the main Changelog file for the Rust solver. The Changelog file fo
      --------------------- -->
 ## Unreleased
 
+### Added
+
+- Implementation of `AffineSpace`
+
 ### Fixed
 
 - Clippy fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ homepage = "https://alphaville.github.io/optimization-engine/"
 repository = "https://github.com/alphaville/optimization-engine"
 
 # Version of this crate (SemVer)
-version = "0.8.1"
+version = "0.9.0"
 
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,9 @@ rpmalloc = { version = "0.2.0", features = [
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = { version = "0.5.0", optional = true }
 
+# Least squares solver
+ndarray = { version = "0.15", features = ["approx"] }
+modcholesky = "0.1.3"
 
 # --------------------------------------------------------------------------
 # F.E.A.T.U.R.E.S.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,4 +68,7 @@ build: false
 #directly or perform other testing commands. Rust will automatically be placed in the PATH
 # environment variable.
 test_script:
+  - cargo add ndarray --features approx
+  - cargo add modcholesky
+  - cargo build
   - cargo test --verbose %cargoflags%

--- a/docs/openrust-basic.md
+++ b/docs/openrust-basic.md
@@ -62,11 +62,15 @@ Constraints implement the namesake trait, [`Constraint`]. Implementations of [`C
 
 | Constraint           | Explanation                                          |
 |----------------------|------------------------------------------------------|
-| [`Ball2`]            | $U {}={} \\{u\in\mathbb{R}^n : \Vert u-u^0\Vert_2 \leq r\\}$         |
-| [`BallInf`]          | $U {}={} \\{u\in\mathbb{R}^n : \Vert u-u^0\Vert_\infty \leq r\\}$         |
+| [`AffineSpace`]      | $U {}={} \\{u\in\mathbb{R}^n : Au = b\\}$         |
+| [`Ball1`]            | $U {}={} \\{u\in\mathbb{R}^n : \Vert u-u^0\Vert_1 \leq r\\}$  |
+| [`Ball2`]            | $U {}={} \\{u\in\mathbb{R}^n : \Vert u-u^0\Vert_2 \leq r\\}$  |
+| [`Sphere2`]          | $U {}={} \\{u\in\mathbb{R}^n : \Vert u-u^0\Vert_2 = r\\}$     |
+| [`BallInf`]          | $U {}={} \\{u\in\mathbb{R}^n : \Vert u-u^0\Vert_\infty \leq r\\}$ |
 | [`Halfspace`]        | $U {}={} \\{u\in\mathbb{R}^n : \langle c, u\rangle \leq b\\}$ |
 | [`Hyperplane`]       | $U {}={} \\{u\in\mathbb{R}^n : \langle c, u\rangle {}={} b\\}$ |
 | [`Rectangle`]        | $U {}={} \\{u\in\mathbb{R}^n : u_{\min} \leq u \leq u_{\max}\\}$ |
+| [`Simplex`]          | $U {}={} \\{u \in \mathbb{R}^n {}:{} u \geq 0, \sum_i u_i = \alpha\\}$ |
 | [`NoConstraints`]    | $U {}={} \mathbb{R}^n$                                   |
 | [`FiniteSet`]        | $U {}={} \\{u^{(1)}, u^{(2)},\ldots,u^{(N)}\\}$          |
 | [`SecondOrderCone`]  | $U {}={} \\{u=(z,t), t\in\mathbb{R}, \Vert{}z{}\Vert \leq \alpha t\\}$ |
@@ -353,6 +357,10 @@ the imposition of a maximum allowed duration, the exit status will be
 <!-- Links -->
 
 [`Constraint`]: https://docs.rs/optimization_engine/*/optimization_engine/constraints/trait.Constraint.html
+[`Simplex`]: https://docs.rs/optimization_engine/*/optimization_engine/constraints/struct.Simplex.html
+[`AffineSpace`]: https://docs.rs/optimization_engine/*/optimization_engine/constraints/struct.AffineSpace.html
+[`Sphere2`]: https://docs.rs/optimization_engine/*/optimization_engine/constraints/struct.Sphere2.html
+[`Ball1`]: https://docs.rs/optimization_engine/*/optimization_engine/constraints/struct.Ball1.html
 [`Ball2`]: https://docs.rs/optimization_engine/*/optimization_engine/constraints/struct.Ball2.html
 [`BallInf`]: https://docs.rs/optimization_engine/*/optimization_engine/constraints/struct.BallInf.html
 [`Halfspace`]: https://docs.rs/optimization_engine/*/optimization_engine/constraints/struct.Halfspace.html

--- a/src/constraints/affine_space.rs
+++ b/src/constraints/affine_space.rs
@@ -80,6 +80,25 @@ impl Constraint for AffineSpace {
     ///
     /// - `x`: The given vector $x$ is updated with the projection on the set
     ///
+    /// ## Example
+    ///
+    /// Consider the set $X = \\{x \in \mathbb{R}^4 :Ax = b\\}$, with $A\in\mathbb{R}^{3\times 4}$
+    /// being the matrix
+    /// $$A = \begin{bmatrix}0.5 & 0.1& 0.2& -0.3\\\\ -0.6& 0.3& 0 & 0.5 \\\\ 1.0& 0.1& -1& -0.4\end{bmatrix},$$
+    /// and $b$ being the vector
+    /// $$b = \begin{bmatrix}1 \\\\ 2 \\\\ -0.5\end{bmatrix}.$$
+    ///
+    /// ```rust
+    /// use optimization_engine::constraints::*;
+    ///
+    /// let a = vec![0.5, 0.1, 0.2, -0.3, -0.6, 0.3, 0., 0.5, 1.0, 0.1, -1.0, -0.4,];
+    /// let b = vec![1., 2., -0.5];
+    /// let affine_set = AffineSpace::new(a, b);
+    /// let mut x = [1., -2., -0.3, 0.5];
+    /// affine_set.project(&mut x);
+    /// ```
+    ///
+    /// The result is stored in `x` and it can be verified that $Ax = b$.
     fn project(&self, x: &mut [f64]) {
         let m = self.n_rows;
         let n = self.n_cols;

--- a/src/constraints/affine_space.rs
+++ b/src/constraints/affine_space.rs
@@ -1,4 +1,8 @@
 use super::Constraint;
+
+extern crate modcholesky;
+extern crate ndarray;
+
 use modcholesky::ModCholeskySE99;
 use ndarray::{Array1, Array2, ArrayBase, Dim, OwnedRepr};
 

--- a/src/constraints/affine_space.rs
+++ b/src/constraints/affine_space.rs
@@ -82,7 +82,19 @@ impl Constraint for AffineSpace {
             y[m] = (err[self.p[m]] - sum) / self.l[(m, m)];
         }
         println!("y = {:?}", y);
-        // Step 2: Solve L'x(P) = y
+        // Step 2: Solve L'z(P) = y
+        let mut z = vec![0.; self.n_rows];
+        z[self.p[self.n_rows - 1]] =
+            y[self.n_rows - 1] / self.l[(self.n_rows - 1, self.n_rows - 1)];
+        for m in (0..self.n_rows - 1).rev() {
+            // TODO! (WIP)
+        }
+        println!("z = {:?}", z);
+        // Step 3: Determine A' * z
+        let z_arr = ndarray::Array1::from_shape_vec((self.n_rows,), z).unwrap();
+        let w = self.a_mat.t().dot(&z_arr);
+        println!("w = {:?}", w);
+        x.iter_mut().zip(w.iter()).for_each(|(xi, wi)| *xi -= wi);
     }
 
     fn is_convex(&self) -> bool {

--- a/src/constraints/affine_space.rs
+++ b/src/constraints/affine_space.rs
@@ -11,10 +11,11 @@ type OpenVec<T> = ndarray::ArrayBase<ndarray::OwnedRepr<T>, ndarray::Dim<[usize;
 pub struct AffineSpace {
     a_mat: OpenMat<f64>,
     b_vec: OpenVec<f64>,
-    a_times_a_t: OpenMat<f64>,
     l: OpenMat<f64>,
     p: OpenVec<usize>,
     e: OpenVec<f64>,
+    n_rows: usize,
+    n_cols: usize,
 }
 
 impl AffineSpace {
@@ -41,25 +42,47 @@ impl AffineSpace {
         let l = res.l;
         let p = res.p;
         let e = res.e;
+        // Print stuff
+        println!("A   = {:?}", a_mat);
+        println!("AA' = {:?}", a_times_a_t);
+        println!("L   = {:?}", l);
+        println!("P   = {:?}", p);
+        println!("E   = {:?}", e);
         // Construct and return new AffineSpace structure
         AffineSpace {
             a_mat,
             b_vec,
-            a_times_a_t,
             l,
             p,
             e,
+            n_rows,
+            n_cols,
         }
     }
 }
 
 impl Constraint for AffineSpace {
     fn project(&self, x: &mut [f64]) {
+        assert!(x.len() == self.n_cols, "x has wrong dimension");
         let x_vec = x.to_vec();
         let x_arr = ndarray::Array1::from_shape_vec((x_vec.len(),), x_vec).unwrap();
         let ax = self.a_mat.dot(&x_arr);
         let err = ax - &self.b_vec;
         println!("err = {:?}", err);
+        // Step 1: Solve Ly = b(P)
+        // TODO: Make `y` into an attribute; however, to do this, we need to change
+        // &self to &mut self, which will require a mild refactoring
+        let mut y = vec![0.; self.n_rows];
+        y[0] = err[self.p[0]] / self.l[(0, 0)];
+        for m in 1..self.n_rows {
+            let mut sum = 0.;
+            for i in 0..m {
+                sum += self.l[(m, i)] * y[i];
+            }
+            y[m] = (err[self.p[m]] - sum) / self.l[(m, m)];
+        }
+        println!("y = {:?}", y);
+        // Step 2: Solve L'x(P) = y
     }
 
     fn is_convex(&self) -> bool {

--- a/src/constraints/affine_space.rs
+++ b/src/constraints/affine_space.rs
@@ -1,19 +1,19 @@
 use super::Constraint;
 use modcholesky::ModCholeskySE99;
+use ndarray::{Array1, Array2, ArrayBase, Dim, OwnedRepr};
 
-type OpenMat<T> = ndarray::ArrayBase<ndarray::OwnedRepr<T>, ndarray::Dim<[usize; 2]>>;
-type OpenVec<T> = ndarray::ArrayBase<ndarray::OwnedRepr<T>, ndarray::Dim<[usize; 1]>>;
+type OpenMat<T> = ArrayBase<OwnedRepr<T>, Dim<[usize; 2]>>;
+type OpenVec<T> = ArrayBase<OwnedRepr<T>, Dim<[usize; 1]>>;
 
 #[derive(Clone)]
 /// An affine space here is defined as the set of solutions of a linear equation, $Ax = b$,
-/// that is, $\{x\in\mathbb{R}^n: Ax = b\}$, which is an affine space. It is assumed that
+/// that is, $E=\\{x\in\mathbb{R}^n: Ax = b\\}$, which is an affine space. It is assumed that
 /// the matrix $AA^\intercal$ is full-rank.
 pub struct AffineSpace {
     a_mat: OpenMat<f64>,
     b_vec: OpenVec<f64>,
     l: OpenMat<f64>,
     p: OpenVec<usize>,
-    e: OpenVec<f64>,
     n_rows: usize,
     n_cols: usize,
 }
@@ -21,18 +21,27 @@ pub struct AffineSpace {
 impl AffineSpace {
     /// Construct a new affine space given the matrix $A\in\mathbb{R}^{m\times n}$ and
     /// the vector $b\in\mathbb{R}^m$
-    pub fn new(a_data: Vec<f64>, b_data: Vec<f64>) -> Self {
+    ///
+    /// ## Arguments
+    ///
+    /// - `a`: matrix $A$, row-wise data
+    /// - `b`: vector $b$
+    ///
+    /// ## Returns
+    /// New Affine Space structure
+    ///
+    pub fn new(a: Vec<f64>, b: Vec<f64>) -> Self {
         // Infer dimensions of A and b
-        let n_rows = b_data.len();
-        let n_elements_a = a_data.len();
+        let n_rows = b.len();
+        let n_elements_a = a.len();
         assert!(
             n_elements_a % n_rows == 0,
             "A and b have incompatible dimensions"
         );
         let n_cols = n_elements_a / n_rows;
         // Cast A and b as ndarray structures
-        let a_mat = ndarray::Array2::from_shape_vec((n_rows, n_cols), a_data).unwrap();
-        let b_vec = ndarray::Array1::from_shape_vec((n_rows,), b_data).unwrap();
+        let a_mat = Array2::from_shape_vec((n_rows, n_cols), a).unwrap();
+        let b_vec = Array1::from_shape_vec((n_rows,), b).unwrap();
         // Compute a permuted Cholesky factorisation of AA'; in particular, we are looking for a
         // minimum-norm matrix E, a permulation matrix P and a lower-trianular L, such that
         //  P(AA' + E)P' = LL'
@@ -41,20 +50,13 @@ impl AffineSpace {
         let res = a_times_a_t.mod_cholesky_se99();
         let l = res.l;
         let p = res.p;
-        let e = res.e;
-        // Print stuff
-        println!("A   = {:?}", a_mat);
-        println!("AA' = {:?}", a_times_a_t);
-        println!("L   = {:?}", l);
-        println!("P   = {:?}", p);
-        println!("E   = {:?}", e);
+
         // Construct and return new AffineSpace structure
         AffineSpace {
             a_mat,
             b_vec,
             l,
             p,
-            e,
             n_rows,
             n_cols,
         }
@@ -62,15 +64,27 @@ impl AffineSpace {
 }
 
 impl Constraint for AffineSpace {
+    /// Projection onto the set $E = \\{x: Ax = b\\}$, which is computed by
+    /// $$P_E(x) = x - A^\intercal z(x),$$
+    /// where $z$ is the solution of the linear system
+    /// $$(AA^\intercal)z = Ax - b,$$
+    /// which has a unique solution provided $A$ has full row rank. The linear system
+    /// is solved by computing the Cholesky factorisation of $AA^\intercal$, which is
+    /// done using [`modcholesky`](https://crates.io/crates/modcholesky).
+    ///
+    /// ## Arguments
+    ///
+    /// - `x`: The given vector $x$ is updated with the projection on the set
+    ///
     fn project(&self, x: &mut [f64]) {
         let m = self.n_rows;
         let n = self.n_cols;
-        let chol: &ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 2]>> = &self.l;
+        let chol = &self.l;
         let perm = &self.p;
 
-        assert!(x.len() == self.n_cols, "x has wrong dimension");
+        assert!(x.len() == n, "x has wrong dimension");
         let x_vec = x.to_vec();
-        let x_arr = ndarray::Array1::from_shape_vec((n,), x_vec).unwrap();
+        let x_arr = Array1::from_shape_vec((n,), x_vec).unwrap();
         let ax = self.a_mat.dot(&x_arr);
         let err = ax - &self.b_vec;
 
@@ -97,13 +111,14 @@ impl Constraint for AffineSpace {
         }
 
         // Step 3: Determine A' * z
-        let z_arr = ndarray::Array1::from_shape_vec((self.n_rows,), z).unwrap();
+        let z_arr = Array1::from_shape_vec((self.n_rows,), z).unwrap();
         let w = self.a_mat.t().dot(&z_arr);
 
         // Step 4: x <-- x - A'(AA')\(Ax-b)
         x.iter_mut().zip(w.iter()).for_each(|(xi, wi)| *xi -= wi);
     }
 
+    /// Affine sets are convex.
     fn is_convex(&self) -> bool {
         true
     }

--- a/src/constraints/affine_space.rs
+++ b/src/constraints/affine_space.rs
@@ -1,0 +1,68 @@
+use super::Constraint;
+use modcholesky::ModCholeskySE99;
+
+type OpenMat<T> = ndarray::ArrayBase<ndarray::OwnedRepr<T>, ndarray::Dim<[usize; 2]>>;
+type OpenVec<T> = ndarray::ArrayBase<ndarray::OwnedRepr<T>, ndarray::Dim<[usize; 1]>>;
+
+#[derive(Clone)]
+/// An affine space here is defined as the set of solutions of a linear equation, $Ax = b$,
+/// that is, $\{x\in\mathbb{R}^n: Ax = b\}$, which is an affine space. It is assumed that
+/// the matrix $AA^\intercal$ is full-rank.
+pub struct AffineSpace {
+    a_mat: OpenMat<f64>,
+    b_vec: OpenVec<f64>,
+    a_times_a_t: OpenMat<f64>,
+    l: OpenMat<f64>,
+    p: OpenVec<usize>,
+    e: OpenVec<f64>,
+}
+
+impl AffineSpace {
+    /// Construct a new affine space given the matrix $A\in\mathbb{R}^{m\times n}$ and
+    /// the vector $b\in\mathbb{R}^m$
+    pub fn new(a_data: Vec<f64>, b_data: Vec<f64>) -> Self {
+        // Infer dimensions of A and b
+        let n_rows = b_data.len();
+        let n_elements_a = a_data.len();
+        assert!(
+            n_elements_a % n_rows == 0,
+            "A and b have incompatible dimensions"
+        );
+        let n_cols = n_elements_a / n_rows;
+        // Cast A and b as ndarray structures
+        let a_mat = ndarray::Array2::from_shape_vec((n_rows, n_cols), a_data).unwrap();
+        let b_vec = ndarray::Array1::from_shape_vec((n_rows,), b_data).unwrap();
+        // Compute a permuted Cholesky factorisation of AA'; in particular, we are looking for a
+        // minimum-norm matrix E, a permulation matrix P and a lower-trianular L, such that
+        //  P(AA' + E)P' = LL'
+        // and E should be 0 if A is full rank.
+        let a_times_a_t = a_mat.dot(&a_mat.t());
+        let res = a_times_a_t.mod_cholesky_se99();
+        let l = res.l;
+        let p = res.p;
+        let e = res.e;
+        // Construct and return new AffineSpace structure
+        AffineSpace {
+            a_mat,
+            b_vec,
+            a_times_a_t,
+            l,
+            p,
+            e,
+        }
+    }
+}
+
+impl Constraint for AffineSpace {
+    fn project(&self, x: &mut [f64]) {
+        let x_vec = x.to_vec();
+        let x_arr = ndarray::Array1::from_shape_vec((x_vec.len(),), x_vec).unwrap();
+        let ax = self.a_mat.dot(&x_arr);
+        let err = ax - &self.b_vec;
+        println!("err = {:?}", err);
+    }
+
+    fn is_convex(&self) -> bool {
+        true
+    }
+}

--- a/src/constraints/affine_space.rs
+++ b/src/constraints/affine_space.rs
@@ -97,11 +97,11 @@ impl Constraint for AffineSpace {
         // &self to &mut self, which will require a mild refactoring
         let mut y = vec![0.; m];
         for i in 0..m {
-            let mut sum = 0.;
+            y[i] = err[perm[i]];
             for j in 0..i {
-                sum += chol[(i, j)] * y[j];
+                y[i] -= chol[(i, j)] * y[j];
             }
-            y[i] = (err[perm[i]] - sum) / chol[(i, i)];
+            y[i] /= chol[(i, i)];
         }
 
         // Step 2: Solve L'z(P) = y

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -8,6 +8,7 @@
 //!
 //! [`Constraint`]: trait.Constraint.html
 
+mod affine_space;
 mod ball1;
 mod ball2;
 mod ballinf;
@@ -22,6 +23,7 @@ mod soc;
 mod sphere2;
 mod zero;
 
+pub use affine_space::AffineSpace;
 pub use ball1::Ball1;
 pub use ball2::Ball2;
 pub use ballinf::BallInf;

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -876,34 +876,11 @@ fn t_ball1_alpha_negative() {
 
 #[test]
 fn t_affine_space() {
-    let data = [10., 2., 2., 15.].to_vec();
-    let datb = vec![1., 2.];
-    // let arr: ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 2]>> =
-    //     ndarray::Array2::from_shape_vec((nrows, ncols), data).unwrap();
-
-    // let asq = arr.dot(&arr.tr());
-    // println!("A2 = {:?}", asq);
-
-    // let arrb: ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 1]>> = ndarray::Array1::from_shape_vec((nrows,), datb).unwrap();
-
+    let data = vec![
+        0.5, 0.1, 0.2, -0.3, -0.6, 0.3, 0., 0.5, 1.0, 0.1, -1.0, -0.4,
+    ];
+    let datb = vec![1., 2., -0.5];
     let aff = AffineSpace::new(data, datb);
-    let mut xx = [1., 1.];
+    let mut xx = [1., -2., -0.3, 0.5];
     aff.project(&mut xx);
-
-    // let a: ndarray::Array2<f64> = ndarray::arr2(&a_data);
-    // let a_cp = a.clone();
-    // let mut a_sq = a.t().dot(&a_cp);
-
-    // println!("A'A = {:?}", a_sq);
-
-    // // Perform modified Cholesky decomposition
-    // // The `Decomposition` struct holds L, E and P
-    // let res = a_sq.mod_cholesky_se99();
-    // let x = a_sq[(res.p, 0)];
-    // let ll = res.l.dot(&res.l.t());
-    // let error = ll;
-
-    // println!("{}", error);
-
-    // println!("{}", res.e);
 }

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -899,6 +899,31 @@ fn t_affine_space() {
 }
 
 #[test]
+fn t_affine_space_larger() {
+    let a = vec![
+        1.0f64, 1., 1., 0., 0., 0., 1., 1., 1., 0., 0., 0., 1., 1., 1., -1., 4., -1., 0., 2.,
+    ];
+    let b = vec![1., -2., 3., 4.];
+    let affine_set = AffineSpace::new(a, b);
+    let mut x = [10., 11., -9., 4., 5.];
+    affine_set.project(&mut x);
+    let x_correct = [
+        9.238095238095237,
+        -0.714285714285714,
+        -7.523809523809524,
+        6.238095238095238,
+        4.285714285714288,
+    ];
+    unit_test_utils::assert_nearly_equal_array(
+        &x_correct,
+        &x,
+        1e-10,
+        1e-12,
+        "projection on affine set is wrong",
+    );
+}
+
+#[test]
 #[should_panic]
 fn t_affine_space_wrong_dimensions() {
     let a = vec![0.5, 0.1, 0.2, -0.3, -0.6, 0.3, 0., 0.5, 1.0, 0.1, -1.0];

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use modcholesky::ModCholeskyGMW81;
 use rand;
 
 #[test]
@@ -871,4 +872,30 @@ fn t_sphere2_center_projection_of_center() {
 #[should_panic]
 fn t_ball1_alpha_negative() {
     let _ = Ball1::new(None, -1.);
+}
+
+#[test]
+fn t_affine_space() {
+    // let m = 4;
+    // let n = 4;
+    // let mut a = Array2::<f64>::zeros((m, n));
+    // a[(0, 0)] = 1.0;
+    // a[(1, 1)] = 1.0;
+    // a[(2, 2)] = 1.0;
+    // a[(3, 3)] = 1.0;
+    // let b = Array1::<f64>::zeros((n,));
+    // let aa = a.t().dot(&a);
+    let a_data = [
+        [1890.3, -1705.6, -315.8, 3000.3],
+        [-1705.6, 1538.3, 284.9, -2706.6],
+        [-315.8, 284.9, 52.5, -501.2],
+        [3000.3, -2706.6, -501.2, 4760.8],
+    ];
+    let a: ndarray::Array2<f64> = ndarray::arr2(&a_data);
+
+    // Perform modified Cholesky decomposition
+    // The `Decomposition` struct holds L, E and P
+    let res = a.mod_cholesky_gmw81();
+
+    println!("{}", res.l);
 }

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use modcholesky::ModCholeskyGMW81;
+use modcholesky::ModCholeskySE99;
 use rand;
 
 #[test]
@@ -876,26 +876,34 @@ fn t_ball1_alpha_negative() {
 
 #[test]
 fn t_affine_space() {
-    // let m = 4;
-    // let n = 4;
-    // let mut a = Array2::<f64>::zeros((m, n));
-    // a[(0, 0)] = 1.0;
-    // a[(1, 1)] = 1.0;
-    // a[(2, 2)] = 1.0;
-    // a[(3, 3)] = 1.0;
-    // let b = Array1::<f64>::zeros((n,));
-    // let aa = a.t().dot(&a);
-    let a_data = [
-        [1890.3, -1705.6, -315.8, 3000.3],
-        [-1705.6, 1538.3, 284.9, -2706.6],
-        [-315.8, 284.9, 52.5, -501.2],
-        [3000.3, -2706.6, -501.2, 4760.8],
-    ];
-    let a: ndarray::Array2<f64> = ndarray::arr2(&a_data);
+    let data = [10., 2., 2., 15.].to_vec();
+    let datb = vec![1., 2.];
+    // let arr: ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 2]>> =
+    //     ndarray::Array2::from_shape_vec((nrows, ncols), data).unwrap();
 
-    // Perform modified Cholesky decomposition
-    // The `Decomposition` struct holds L, E and P
-    let res = a.mod_cholesky_gmw81();
+    // let asq = arr.dot(&arr.tr());
+    // println!("A2 = {:?}", asq);
 
-    println!("{}", res.l);
+    // let arrb: ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 1]>> = ndarray::Array1::from_shape_vec((nrows,), datb).unwrap();
+
+    let aff = AffineSpace::new(data, datb);
+    let mut xx = [1., 1.];
+    aff.project(&mut xx);
+
+    // let a: ndarray::Array2<f64> = ndarray::arr2(&a_data);
+    // let a_cp = a.clone();
+    // let mut a_sq = a.t().dot(&a_cp);
+
+    // println!("A'A = {:?}", a_sq);
+
+    // // Perform modified Cholesky decomposition
+    // // The `Decomposition` struct holds L, E and P
+    // let res = a_sq.mod_cholesky_se99();
+    // let x = a_sq[(res.p, 0)];
+    // let ll = res.l.dot(&res.l.t());
+    // let error = ll;
+
+    // println!("{}", error);
+
+    // println!("{}", res.e);
 }

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -876,12 +876,32 @@ fn t_ball1_alpha_negative() {
 
 #[test]
 fn t_affine_space() {
-    let data = vec![
+    let a = vec![
         0.5, 0.1, 0.2, -0.3, -0.6, 0.3, 0., 0.5, 1.0, 0.1, -1.0, -0.4,
     ];
-    let datb = vec![1., 2., -0.5];
-    let aff = AffineSpace::new(data, datb);
-    let mut xx = [1., -2., -0.3, 0.5];
-    aff.project(&mut xx);
-    println!("x = {:?}", xx);
+    let b = vec![1., 2., -0.5];
+    let affine_set = AffineSpace::new(a, b);
+    let mut x = [1., -2., -0.3, 0.5];
+    affine_set.project(&mut x);
+    let x_correct = [
+        1.888564346697095,
+        5.629857182200888,
+        1.796204902230790,
+        2.888362906715977,
+    ];
+    unit_test_utils::assert_nearly_equal_array(
+        &x_correct,
+        &x,
+        1e-10,
+        1e-12,
+        "projection on affine set is wrong",
+    );
+}
+
+#[test]
+#[should_panic]
+fn t_affine_space_wrong_dimensions() {
+    let a = vec![0.5, 0.1, 0.2, -0.3, -0.6, 0.3, 0., 0.5, 1.0, 0.1, -1.0];
+    let b = vec![1., 2., -0.5];
+    let _ = AffineSpace::new(a, b);
 }

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -924,6 +924,17 @@ fn t_affine_space_larger() {
 }
 
 #[test]
+fn t_affine_space_single_row() {
+    let a = vec![1., 1., 1., 1.];
+    let b = vec![1.];
+    let affine_set = AffineSpace::new(a, b);
+    let mut x = [5., 6., 10., 25.];
+    affine_set.project(&mut x);
+    let s = x.iter().sum();
+    unit_test_utils::assert_nearly_equal(1., s, 1e-12, 1e-14, "wrong sum");
+}
+
+#[test]
 #[should_panic]
 fn t_affine_space_wrong_dimensions() {
     let a = vec![0.5, 0.1, 0.2, -0.3, -0.6, 0.3, 0., 0.5, 1.0, 0.1, -1.0];

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -883,4 +883,5 @@ fn t_affine_space() {
     let aff = AffineSpace::new(data, datb);
     let mut xx = [1., -2., -0.3, 0.5];
     aff.project(&mut xx);
+    println!("x = {:?}", xx);
 }


### PR DESCRIPTION
## The method

Let $A\in\mathbb{R}^{m\times n}$ with ${\rm rank} A = m$ and $m \leq n$ (typically $m < n$). Let $b\in\mathbb{R}^m$. The projection of a vector $x\in\mathbb{R}^n$ on the set $X = \\{x: Ax = b\\}$ is given by 
$$\Pi_X(x) = \mathrm{argmin}_{z\in X} \frac{1}{2}\\|x - z\\|^2.$$

This is a convex QP with Lagrangian 
$$L(z, \lambda) = \frac{1}{2}\\|x-z\\|^2 + \lambda^\intercal (Az-b),$$
and its gradients with respect to $z$ and $\lambda$ are 
$$\nabla_z L(z, \lambda) = x - z + A^\intercal \lambda$$
and 
$$\nabla_\lambda L(z, \lambda) = Az - b.$$
We are looking for a pair $(z^\star, \lambda^\star)$ such that $\nabla_z L(z^\star, \lambda^\star) = 0$ and $\nabla_\lambda L(z^\star, \lambda^\star) = 0$, that is,

$$\begin{aligned}x - z^\star + A^\intercal \lambda^\star = 0, \\\\ Az^\star - b = 0.\end{aligned}$$

Multiplying the first equation by $A$ from the left and substituting $Az^\star = b$ we have

$$Ax - b + AA^\intercal \lambda^\star = 0 \Rightarrow AA^\intercal \lambda^\star = Ax - b,$$

We can solve this linear equaltion by computing the Cholesky factorisation of $AA^\intercal$, that is, $PAA^\intercal P^\intercal = LL^\intercal,$ where $L$ is a lower triangular matrix and $P$ is a permutation matrix. Having solved this for $\lambda^\star$, we can compute 

$$z^\star = x - A^\intercal \lambda^\star.$$

We can also write

$$z^\star = x - A^\intercal (AA^\intercal)^{-1}(Ax-b).$$


## Main Changes

- Implementation of projection on affine spaces of the form $\\{x: Ax = b\\}$
- Unit tests in Rust

## Associated Issues

- None

## TODOs

- [x] API Docs
- [x] All tests must pass
- [x] Update `CHANGELOG`(s)
- [x] Update webpage documentation
- [x] Bump versions (in `CHANGELOG`, `Cargo.toml` and `VERSION`)
