### PR TITLE
Fixed small typo in navigation_py docs: pythong->python

### DIFF
--- a/docs/example_navigation_py.md
+++ b/docs/example_navigation_py.md
@@ -167,7 +167,7 @@ plt.show()
 <!--Direct Interface-->
 ```python
 # Note: to use the direct interface you need to build using
-#       .with_build_pythong_bindings()
+#       .with_build_python_bindings()
 import sys
 
 # Use Direct Interface


### PR DESCRIPTION
## Main Changes

Fixes #335 changing changing `.with_build_pythong_bindings()` to `.with_build_python_bindings()` as explained below:

In the python example for [navigation](https://alphaville.github.io/optimization-engine/docs/example_navigation_py), the proposed codeblock for the use of the functions using the Direct Interface, there is a note that says

    # Note: to use the direct interface you need to build using
    #       .with_build_pythong_bindings()
    import sys
    ....

However, this does not exist. I supposed it was a small spelling mistake and I fixed in this PR to:

    # Note: to use the direct interface you need to build using
    #       .with_build_python_bindings()
    import sys
    ....


