### PR TITLE
:bug: Modify cargo.toml for windows environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,12 +94,6 @@ rpmalloc = { version = "0.2", features = [
     "statistics",
 ], optional = true }
 
-# jemallocator is an optional feature; it will only be loaded if the feature 
-# `jem` is used (i.e., if we compile with `cargo build --features jem`)
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { version = "0.5", optional = true }
-
-
 # computation of roots of cubic equation needed for the projection on the 
 # epigraph of the squared Euclidean norm
 roots = "0.0.8"
@@ -108,6 +102,10 @@ roots = "0.0.8"
 ndarray = { version = "0.15", features = ["approx"] }
 modcholesky = "0.1"
 
+# jemallocator is an optional feature; it will only be loaded if the feature 
+# `jem` is used (i.e., if we compile with `cargo build --features jem`)
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = { version = "0.5", optional = true }
 
 # --------------------------------------------------------------------------
 # F.E.A.T.U.R.E.S.


### PR DESCRIPTION
## Main Changes

- Modify the current posiiton of crates `roots`, `ndarray`, `modcholesky` to be above `[target.'cfg(not(target_env = "msvc"))'.dependencies]` so they can be installed when `cargo build` on Windows OS 

Test on:

- System/Platform: PC
- OS: Windows 11
- rustup version: 1.27.1
- rustc version: 1.80.1
- cargo version: 1.80.1
- Python version: 3.11.4

Evidence of `cargo build`'s output 

![Screenshot 2024-08-14 172921](https://github.com/user-attachments/assets/fa42233e-083d-4466-b2ba-a859ee77fe33)


## Associated Issues

- Closes https://github.com/alphaville/optimization-engine/issues/348
