### PR TITLE
Make core generic over float types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ rustdoc-args = ["--html-in-header", "katex-header.html"]
 num = "0.4"
 
 # Our own stuff - L-BFGS: limited-memory BFGS directions
-lbfgs = "0.2"
+lbfgs = { version = "0.2" }
 
 # Instant is a generic timer that works on Wasm (with wasm-bindgen)
 instant = { version = "0.1" }
@@ -147,3 +147,7 @@ travis-ci = { repository = "alphaville/optimization-engine", branch = "master" }
 
 # Actively maintained badge
 maintenance = { status = "actively-developed" }
+
+[patch.crates-io]
+# Add support for generic floating point types
+lbfgs = { git = "https://github.com/AutoPallet/lbfgs-rs.git", rev = "9f450872cb2da6bc7d3ebb79f32e29550689ecb0" }

--- a/src/alm/alm_cache.rs
+++ b/src/alm/alm_cache.rs
@@ -1,4 +1,5 @@
 use crate::panoc::PANOCCache;
+use crate::OptFloat;
 
 const DEFAULT_INITIAL_PENALTY: f64 = 10.0;
 
@@ -12,32 +13,35 @@ const DEFAULT_INITIAL_PENALTY: f64 = 10.0;
 /// of `AlmProblem`
 ///
 #[derive(Debug)]
-pub struct AlmCache {
+pub struct AlmCache<T>
+where
+    T: OptFloat,
+{
     /// PANOC cache for inner problems
-    pub(crate) panoc_cache: PANOCCache,
+    pub(crate) panoc_cache: PANOCCache<T>,
     /// Lagrange multipliers (next)
-    pub(crate) y_plus: Option<Vec<f64>>,
+    pub(crate) y_plus: Option<Vec<T>>,
     /// Vector $\xi^\nu = (c^\nu, y^\nu)$
-    pub(crate) xi: Option<Vec<f64>>,
+    pub(crate) xi: Option<Vec<T>>,
     /// Infeasibility related to ALM-type constraints
-    pub(crate) delta_y_norm: f64,
+    pub(crate) delta_y_norm: T,
     /// Delta y at iteration `nu+1`
-    pub(crate) delta_y_norm_plus: f64,
+    pub(crate) delta_y_norm_plus: T,
     /// Value $\Vert F_2(u^\nu) \Vert$
-    pub(crate) f2_norm: f64,
+    pub(crate) f2_norm: T,
     /// Value $\Vert F_2(u^{\nu+1}) \Vert$
-    pub(crate) f2_norm_plus: f64,
+    pub(crate) f2_norm_plus: T,
     /// Auxiliary variable `w`
-    pub(crate) w_alm_aux: Option<Vec<f64>>,
+    pub(crate) w_alm_aux: Option<Vec<T>>,
     /// Infeasibility related to PM-type constraints, `w_pm = F2(u)`
-    pub(crate) w_pm: Option<Vec<f64>>,
+    pub(crate) w_pm: Option<Vec<T>>,
     /// (Outer) iteration count
     pub(crate) iteration: usize,
     /// Counter for inner iterations
     pub(crate) inner_iteration_count: usize,
     /// Value of the norm of the fixed-point residual for the last
     /// solved inner problem
-    pub(crate) last_inner_problem_norm_fpr: f64,
+    pub(crate) last_inner_problem_norm_fpr: T,
     /// Available time left for ALM/PM computations (the value `None`
     /// corresponds to an unspecified available time, i.e., there are
     /// no bounds on the maximum time). The maximum time is specified,
@@ -45,7 +49,10 @@ pub struct AlmCache {
     pub(crate) available_time: Option<std::time::Duration>,
 }
 
-impl AlmCache {
+impl<T> AlmCache<T>
+where
+    T: OptFloat,
+{
     /// Construct a new instance of `AlmCache`
     ///
     /// # Arguments
@@ -58,30 +65,42 @@ impl AlmCache {
     ///
     /// Does not panic
     ///
-    pub fn new(panoc_cache: PANOCCache, n1: usize, n2: usize) -> Self {
+    pub fn new(panoc_cache: PANOCCache<T>, n1: usize, n2: usize) -> Self {
         AlmCache {
             panoc_cache,
-            y_plus: if n1 > 0 { Some(vec![0.0; n1]) } else { None },
+            y_plus: if n1 > 0 {
+                Some(vec![T::zero(); n1])
+            } else {
+                None
+            },
             // Allocate memory for xi = (c, y) if either n1 or n2 is nonzero,
             // otherwise, xi is None
             xi: if n1 + n2 > 0 {
-                let mut xi_init = vec![DEFAULT_INITIAL_PENALTY; 1];
-                xi_init.append(&mut vec![0.0; n1]);
+                let mut xi_init = vec![T::from(DEFAULT_INITIAL_PENALTY).unwrap(); 1];
+                xi_init.append(&mut vec![T::zero(); n1]);
                 Some(xi_init)
             } else {
                 None
             },
             // w_alm_aux should be allocated only if n1 > 0
-            w_alm_aux: if n1 > 0 { Some(vec![0.0; n1]) } else { None },
+            w_alm_aux: if n1 > 0 {
+                Some(vec![T::zero(); n1])
+            } else {
+                None
+            },
             // w_pm is needed only if n2 > 0
-            w_pm: if n2 > 0 { Some(vec![0.0; n2]) } else { None },
+            w_pm: if n2 > 0 {
+                Some(vec![T::zero(); n2])
+            } else {
+                None
+            },
             iteration: 0,
-            delta_y_norm: 0.0,
-            delta_y_norm_plus: std::f64::INFINITY,
-            f2_norm: 0.0,
-            f2_norm_plus: std::f64::INFINITY,
+            delta_y_norm: T::zero(),
+            delta_y_norm_plus: T::infinity(),
+            f2_norm: T::zero(),
+            f2_norm_plus: T::infinity(),
             inner_iteration_count: 0,
-            last_inner_problem_norm_fpr: -1.0,
+            last_inner_problem_norm_fpr: T::from(-1.0).unwrap(),
             available_time: None,
         }
     }
@@ -92,10 +111,10 @@ impl AlmCache {
     pub fn reset(&mut self) {
         self.panoc_cache.reset();
         self.iteration = 0;
-        self.f2_norm = 0.0;
-        self.f2_norm_plus = 0.0;
-        self.delta_y_norm = 0.0;
-        self.delta_y_norm_plus = 0.0;
+        self.f2_norm = T::zero();
+        self.f2_norm_plus = T::zero();
+        self.delta_y_norm = T::zero();
+        self.delta_y_norm_plus = T::zero();
         self.inner_iteration_count = 0;
     }
 }

--- a/src/alm/alm_optimizer_status.rs
+++ b/src/alm/alm_optimizer_status.rs
@@ -1,5 +1,4 @@
-use crate::core::ExitStatus;
-
+use crate::core::{ExitStatus, OptFloat};
 /// Solution statistics for `AlmOptimizer`
 ///
 /// This structure has no public fields and no public setter methods.  
@@ -7,7 +6,10 @@ use crate::core::ExitStatus;
 /// `AlmOptimizerStatus` instances.
 ///
 #[derive(Debug)]
-pub struct AlmOptimizerStatus {
+pub struct AlmOptimizerStatus<T>
+where
+    T: OptFloat,
+{
     /// Exit status
     exit_status: ExitStatus,
     /// Number of outer iterations
@@ -18,23 +20,26 @@ pub struct AlmOptimizerStatus {
     /// inner solvers
     num_inner_iterations: usize,
     /// Norm of the fixed-point residual of the the problem
-    last_problem_norm_fpr: f64,
+    last_problem_norm_fpr: T,
     ///
-    lagrange_multipliers: Option<Vec<f64>>,
+    lagrange_multipliers: Option<Vec<T>>,
     /// Total solve time
     solve_time: std::time::Duration,
     /// Last value of penalty parameter
-    penalty: f64,
+    penalty: T,
     /// A measure of infeasibility of constraints F1(u; p) in C
-    delta_y_norm: f64,
+    delta_y_norm: T,
     /// Norm of F2 at the solution, which is a measure of infeasibility
     /// of constraints F2(u; p) = 0
-    f2_norm: f64,
+    f2_norm: T,
     /// Value of cost function at optimal solution (optimal cost)
-    cost: f64,
+    cost: T,
 }
 
-impl AlmOptimizerStatus {
+impl<T> AlmOptimizerStatus<T>
+where
+    T: OptFloat,
+{
     /// Constructor for instances of `AlmOptimizerStatus`
     ///
     /// This method is only accessibly within this crate.
@@ -60,13 +65,13 @@ impl AlmOptimizerStatus {
             exit_status,
             num_outer_iterations: 0,
             num_inner_iterations: 0,
-            last_problem_norm_fpr: -1.0,
+            last_problem_norm_fpr: T::from(-1.0).unwrap(),
             lagrange_multipliers: None,
             solve_time: std::time::Duration::from_nanos(0),
-            penalty: 0.0,
-            delta_y_norm: 0.0,
-            f2_norm: 0.0,
-            cost: 0.0,
+            penalty: T::zero(),
+            delta_y_norm: T::zero(),
+            f2_norm: T::zero(),
+            cost: T::zero(),
         }
     }
 
@@ -129,7 +134,7 @@ impl AlmOptimizerStatus {
     /// Does not panic; it is the responsibility of the caller to provide a vector of
     /// Lagrange multipliers of correct length
     ///
-    pub(crate) fn with_lagrange_multipliers(mut self, lagrange_multipliers: &[f64]) -> Self {
+    pub(crate) fn with_lagrange_multipliers(mut self, lagrange_multipliers: &[T]) -> Self {
         self.lagrange_multipliers = Some(vec![]);
         if let Some(y) = &mut self.lagrange_multipliers {
             y.extend_from_slice(lagrange_multipliers);
@@ -144,9 +149,9 @@ impl AlmOptimizerStatus {
     ///
     /// The method panics if the provided penalty parameter is negative
     ///
-    pub(crate) fn with_penalty(mut self, penalty: f64) -> Self {
+    pub(crate) fn with_penalty(mut self, penalty: T) -> Self {
         assert!(
-            penalty >= 0.0,
+            penalty >= T::zero(),
             "the penalty parameter should not be negative"
         );
         self.penalty = penalty;
@@ -161,28 +166,31 @@ impl AlmOptimizerStatus {
     /// The method panics if the provided norm of the fixed-point residual is
     /// negative
     ///
-    pub(crate) fn with_last_problem_norm_fpr(mut self, last_problem_norm_fpr: f64) -> Self {
+    pub(crate) fn with_last_problem_norm_fpr(mut self, last_problem_norm_fpr: T) -> Self {
         assert!(
-            last_problem_norm_fpr >= 0.0,
+            last_problem_norm_fpr >= T::zero(),
             "last_problem_norm_fpr should not be negative"
         );
         self.last_problem_norm_fpr = last_problem_norm_fpr;
         self
     }
 
-    pub(crate) fn with_delta_y_norm(mut self, delta_y_norm: f64) -> Self {
-        assert!(delta_y_norm >= 0.0, "delta_y_norm must be nonnegative");
+    pub(crate) fn with_delta_y_norm(mut self, delta_y_norm: T) -> Self {
+        assert!(
+            delta_y_norm >= T::zero(),
+            "delta_y_norm must be nonnegative"
+        );
         self.delta_y_norm = delta_y_norm;
         self
     }
 
-    pub(crate) fn with_f2_norm(mut self, f2_norm: f64) -> Self {
-        assert!(f2_norm >= 0.0, "f2_norm must be nonnegative");
+    pub(crate) fn with_f2_norm(mut self, f2_norm: T) -> Self {
+        assert!(f2_norm >= T::zero(), "f2_norm must be nonnegative");
         self.f2_norm = f2_norm;
         self
     }
 
-    pub(crate) fn with_cost(mut self, cost: f64) -> Self {
+    pub(crate) fn with_cost(mut self, cost: T) -> Self {
         self.cost = cost;
         self
     }
@@ -192,17 +200,17 @@ impl AlmOptimizerStatus {
     // -------------------------------------------------
 
     /// Update cost (to be used when the cost needs to be scaled as a result of preconditioning)
-    pub fn update_cost(&mut self, new_cost: f64) {
+    pub fn update_cost(&mut self, new_cost: T) {
         self.cost = new_cost;
     }
 
     /// Update ALM infeasibility
-    pub fn update_f1_infeasibility(&mut self, new_alm_infeasibility: f64) {
+    pub fn update_f1_infeasibility(&mut self, new_alm_infeasibility: T) {
         self.delta_y_norm = new_alm_infeasibility;
     }
 
     /// Update PM infeasibility
-    pub fn update_f2_norm(&mut self, new_pm_infeasibility: f64) {
+    pub fn update_f2_norm(&mut self, new_pm_infeasibility: T) {
         self.f2_norm = new_pm_infeasibility;
     }
 
@@ -249,7 +257,7 @@ impl AlmOptimizerStatus {
     ///
     /// Does not panic
     ///
-    pub fn lagrange_multipliers(&self) -> &Option<Vec<f64>> {
+    pub fn lagrange_multipliers(&self) -> &Option<Vec<T>> {
         &self.lagrange_multipliers
     }
 
@@ -259,7 +267,7 @@ impl AlmOptimizerStatus {
     ///
     /// Does not panic
     ///
-    pub fn last_problem_norm_fpr(&self) -> f64 {
+    pub fn last_problem_norm_fpr(&self) -> T {
         self.last_problem_norm_fpr
     }
 
@@ -278,23 +286,23 @@ impl AlmOptimizerStatus {
     /// # Panics
     ///
     /// Does not panic
-    pub fn penalty(&self) -> f64 {
+    pub fn penalty(&self) -> T {
         self.penalty
     }
 
     /// Norm of Delta y divided by max{c, 1} - measure of infeasibility
-    pub fn delta_y_norm_over_c(&self) -> f64 {
+    pub fn delta_y_norm_over_c(&self) -> T {
         let c = self.penalty();
-        self.delta_y_norm / if c < 1.0 { 1.0 } else { c }
+        self.delta_y_norm / if c < T::one() { T::one() } else { c }
     }
 
     /// Norm of F2(u) - measure of infeasibility of F2(u) = 0
-    pub fn f2_norm(&self) -> f64 {
+    pub fn f2_norm(&self) -> T {
         self.f2_norm
     }
 
     /// Value of the cost function at the solution
-    pub fn cost(&self) -> f64 {
+    pub fn cost(&self) -> T {
         self.cost
     }
 }

--- a/src/alm/alm_problem.rs
+++ b/src/alm/alm_problem.rs
@@ -1,4 +1,5 @@
-use crate::{constraints::Constraint, FunctionCallResult};
+use crate::constraints::Constraint;
+use crate::{FunctionCallResult, OptFloat};
 
 /// Definition of optimization problem to be solved with `AlmOptimizer`. The optimization
 /// problem has the general form
@@ -32,16 +33,18 @@ pub struct AlmProblem<
     ConstraintsType,
     AlmSetC,
     LagrangeSetY,
+    T,
 > where
     // This is function F1: R^xn --> R^n1 (ALM)
-    MappingAlm: Fn(&[f64], &mut [f64]) -> FunctionCallResult,
+    MappingAlm: Fn(&[T], &mut [T]) -> FunctionCallResult,
     // This is function F2: R^xn --> R^n2 (PM)
-    MappingPm: Fn(&[f64], &mut [f64]) -> FunctionCallResult,
-    ParametricGradientType: Fn(&[f64], &[f64], &mut [f64]) -> FunctionCallResult,
-    ParametricCostType: Fn(&[f64], &[f64], &mut f64) -> FunctionCallResult,
-    ConstraintsType: Constraint,
-    AlmSetC: Constraint,
-    LagrangeSetY: Constraint,
+    MappingPm: Fn(&[T], &mut [T]) -> FunctionCallResult,
+    ParametricGradientType: Fn(&[T], &[T], &mut [T]) -> FunctionCallResult,
+    ParametricCostType: Fn(&[T], &[T], &mut T) -> FunctionCallResult,
+    ConstraintsType: Constraint<T>,
+    AlmSetC: Constraint<T>,
+    LagrangeSetY: Constraint<T>,
+    T: OptFloat,
 {
     //
     // NOTE: the reason why we need to define different set types (ConstraintsType,
@@ -67,6 +70,8 @@ pub struct AlmProblem<
     pub(crate) n1: usize,
     /// number of PM-type parameters (range dim of F2)
     pub(crate) n2: usize,
+
+    _t: std::marker::PhantomData<T>,
 }
 
 impl<
@@ -77,6 +82,7 @@ impl<
         ConstraintsType,
         AlmSetC,
         LagrangeSetY,
+        T,
     >
     AlmProblem<
         MappingAlm,
@@ -86,15 +92,17 @@ impl<
         ConstraintsType,
         AlmSetC,
         LagrangeSetY,
+        T,
     >
 where
-    MappingAlm: Fn(&[f64], &mut [f64]) -> FunctionCallResult,
-    MappingPm: Fn(&[f64], &mut [f64]) -> FunctionCallResult,
-    ParametricGradientType: Fn(&[f64], &[f64], &mut [f64]) -> FunctionCallResult,
-    ParametricCostType: Fn(&[f64], &[f64], &mut f64) -> FunctionCallResult,
-    ConstraintsType: Constraint,
-    AlmSetC: Constraint,
-    LagrangeSetY: Constraint,
+    MappingAlm: Fn(&[T], &mut [T]) -> FunctionCallResult,
+    MappingPm: Fn(&[T], &mut [T]) -> FunctionCallResult,
+    ParametricGradientType: Fn(&[T], &[T], &mut [T]) -> FunctionCallResult,
+    ParametricCostType: Fn(&[T], &[T], &mut T) -> FunctionCallResult,
+    ConstraintsType: Constraint<T>,
+    AlmSetC: Constraint<T>,
+    LagrangeSetY: Constraint<T>,
+    T: OptFloat,
 {
     ///Constructs new instance of `AlmProblem`
     ///
@@ -163,6 +171,7 @@ where
             mapping_f2,
             n1,
             n2,
+            _t: std::marker::PhantomData,
         }
     }
 }

--- a/src/alm/tests.rs
+++ b/src/alm/tests.rs
@@ -1,8 +1,8 @@
-use crate::{
-    alm::*,
-    core::{constraints::*, panoc::*, ExitStatus},
-    matrix_operations, mocks, FunctionCallResult, SolverError,
-};
+use crate::alm::*;
+use crate::core::constraints::*;
+use crate::core::panoc::*;
+use crate::core::ExitStatus;
+use crate::{matrix_operations, mocks, FunctionCallResult, SolverError};
 
 #[test]
 fn t_create_alm_cache() {

--- a/src/constraints/ball1.rs
+++ b/src/constraints/ball1.rs
@@ -1,20 +1,26 @@
-use super::Constraint;
-use super::Simplex;
+use super::{Constraint, Simplex};
+use crate::core::OptFloat;
 
 #[derive(Copy, Clone)]
 /// A norm-1 ball, that is, a set given by $B_1^r = \\{x \in \mathbb{R}^n {}:{} \Vert{}x{}\Vert_1 \leq r\\}$
 /// or a ball-1 centered at a point $x_c$, that is, $B_1^{x_c, r} = \\{x \in \mathbb{R}^n {}:{} \Vert{}x-x_c{}\Vert_1 \leq r\\}$
-pub struct Ball1<'a> {
-    center: Option<&'a [f64]>,
-    radius: f64,
-    simplex: Simplex,
+pub struct Ball1<'a, T>
+where
+    T: OptFloat,
+{
+    center: Option<&'a [T]>,
+    radius: T,
+    simplex: Simplex<T>,
 }
 
-impl<'a> Ball1<'a> {
+impl<'a, T> Ball1<'a, T>
+where
+    T: OptFloat + PartialOrd + Copy,
+{
     /// Construct a new ball-1 with given center and radius.
     /// If no `center` is given, then it is assumed to be in the origin
-    pub fn new(center: Option<&'a [f64]>, radius: f64) -> Self {
-        assert!(radius > 0.0);
+    pub fn new(center: Option<&'a [T]>, radius: T) -> Self {
+        assert!(radius > T::zero());
         let simplex = Simplex::new(radius);
         Ball1 {
             center,
@@ -23,24 +29,27 @@ impl<'a> Ball1<'a> {
         }
     }
 
-    fn project_on_ball1_centered_at_origin(&self, x: &mut [f64]) {
+    fn project_on_ball1_centered_at_origin(&self, x: &mut [T]) {
         if crate::matrix_operations::norm1(x) > self.radius {
             // u = |x| (copied)
-            let mut u = vec![0.0; x.len()];
+            let mut u = vec![T::zero(); x.len()];
             u.iter_mut()
                 .zip(x.iter())
-                .for_each(|(ui, &xi)| *ui = f64::abs(xi));
+                .for_each(|(ui, &xi)| *ui = xi.abs());
             // u = P_simplex(u)
             self.simplex.project(&mut u);
             x.iter_mut()
                 .zip(u.iter())
-                .for_each(|(xi, &ui)| *xi = f64::signum(*xi) * ui);
+                .for_each(|(xi, &ui)| *xi = xi.signum() * ui);
         }
     }
 }
 
-impl<'a> Constraint for Ball1<'a> {
-    fn project(&self, x: &mut [f64]) {
+impl<'a, T> Constraint<T> for Ball1<'a, T>
+where
+    T: OptFloat + PartialOrd + Copy,
+{
+    fn project(&self, x: &mut [T]) {
         if let Some(center) = &self.center {
             x.iter_mut()
                 .zip(center.iter())

--- a/src/constraints/ball2.rs
+++ b/src/constraints/ball2.rs
@@ -1,30 +1,40 @@
 use super::Constraint;
+use crate::core::OptFloat;
 
 #[derive(Copy, Clone)]
 /// A Euclidean ball, that is, a set given by $B_2^r = \\{x \in \mathbb{R}^n {}:{} \Vert{}x{}\Vert \leq r\\}$
 /// or a Euclidean ball centered at a point $x_c$, that is, $B_2^{x_c, r} = \\{x \in \mathbb{R}^n {}:{} \Vert{}x-x_c{}\Vert \leq r\\}$
-pub struct Ball2<'a> {
-    center: Option<&'a [f64]>,
-    radius: f64,
+pub struct Ball2<'a, T>
+where
+    T: OptFloat,
+{
+    center: Option<&'a [T]>,
+    radius: T,
 }
 
-impl<'a> Ball2<'a> {
+impl<'a, T> Ball2<'a, T>
+where
+    T: OptFloat,
+{
     /// Construct a new Euclidean ball with given center and radius
     /// If no `center` is given, then it is assumed to be in the origin
-    pub fn new(center: Option<&'a [f64]>, radius: f64) -> Self {
-        assert!(radius > 0.0);
+    pub fn new(center: Option<&'a [T]>, radius: T) -> Self {
+        assert!(radius > T::zero());
 
         Ball2 { center, radius }
     }
 }
 
-impl<'a> Constraint for Ball2<'a> {
-    fn project(&self, x: &mut [f64]) {
+impl<'a, T> Constraint<T> for Ball2<'a, T>
+where
+    T: OptFloat,
+{
+    fn project(&self, x: &mut [T]) {
         if let Some(center) = &self.center {
-            let mut norm_difference = 0.0;
+            let mut norm_difference = T::zero();
             x.iter().zip(center.iter()).for_each(|(a, b)| {
                 let diff_ = *a - *b;
-                norm_difference += diff_ * diff_
+                norm_difference += diff_ * diff_;
             });
 
             norm_difference = norm_difference.sqrt();
@@ -38,7 +48,7 @@ impl<'a> Constraint for Ball2<'a> {
             let norm_x = crate::matrix_operations::norm2(x);
             if norm_x > self.radius {
                 let norm_over_radius = norm_x / self.radius;
-                x.iter_mut().for_each(|x_| *x_ /= norm_over_radius);
+                x.iter_mut().for_each(|x_| *x_ = *x_ / norm_over_radius);
             }
         }
     }

--- a/src/constraints/ballinf.rs
+++ b/src/constraints/ballinf.rs
@@ -1,26 +1,36 @@
 use super::Constraint;
+use crate::core::OptFloat;
 
 #[derive(Copy, Clone)]
 /// An infinity ball defined as $B_\infty^r = \\{x\in\mathbb{R}^n {}:{} \Vert{}x{}\Vert_{\infty} \leq r\\}$,
 /// where $\Vert{}\cdot{}\Vert_{\infty}$ is the infinity norm. The infinity ball centered at a point
 /// $x_c$ is defined as $B_\infty^{x_c,r} = \\{x\in\mathbb{R}^n {}:{} \Vert{}x-x_c{}\Vert_{\infty} \leq r\\}$.
 ///
-pub struct BallInf<'a> {
-    center: Option<&'a [f64]>,
-    radius: f64,
+pub struct BallInf<'a, T>
+where
+    T: OptFloat,
+{
+    center: Option<&'a [T]>,
+    radius: T,
 }
 
-impl<'a> BallInf<'a> {
+impl<'a, T> BallInf<'a, T>
+where
+    T: OptFloat,
+{
     /// Construct a new infinity-norm ball with given center and radius
     /// If no `center` is given, then it is assumed to be in the origin
     ///   
-    pub fn new(center: Option<&'a [f64]>, radius: f64) -> Self {
-        assert!(radius > 0.0);
+    pub fn new(center: Option<&'a [T]>, radius: T) -> Self {
+        assert!(radius > T::zero());
         BallInf { center, radius }
     }
 }
 
-impl<'a> Constraint for BallInf<'a> {
+impl<'a, T> Constraint<T> for BallInf<'a, T>
+where
+    T: OptFloat,
+{
     /// Computes the projection of a given vector `x` on the current infinity ball.
     ///
     ///
@@ -42,12 +52,12 @@ impl<'a> Constraint for BallInf<'a> {
     ///
     /// for all $i=1,\ldots, n$.
     ///
-    fn project(&self, x: &mut [f64]) {
+    fn project(&self, x: &mut [T]) {
         if let Some(center) = &self.center {
             x.iter_mut()
                 .zip(center.iter())
                 .filter(|(&mut xi, &ci)| (xi - ci).abs() > self.radius)
-                .for_each(|(xi, ci)| *xi = ci + (*xi - ci).signum() * self.radius);
+                .for_each(|(xi, ci)| *xi = *ci + (*xi - *ci).signum() * self.radius);
         } else {
             x.iter_mut()
                 .filter(|xi| xi.abs() > self.radius)

--- a/src/constraints/cartesian_product.rs
+++ b/src/constraints/cartesian_product.rs
@@ -1,5 +1,5 @@
 use super::Constraint;
-
+use crate::core::OptFloat;
 /// Cartesian product of constraints
 ///
 /// Cartesian product of constraints, $C_0, C_1, \ldots, C_{n-1}$,
@@ -22,12 +22,18 @@ use super::Constraint;
 /// for all $i=0,\ldots, n-1$.
 ///
 #[derive(Default)]
-pub struct CartesianProduct<'a> {
+pub struct CartesianProduct<'a, T>
+where
+    T: OptFloat,
+{
     idx: Vec<usize>,
-    constraints: Vec<Box<dyn Constraint + 'a>>,
+    constraints: Vec<Box<dyn Constraint<T> + 'a>>,
 }
 
-impl<'a> CartesianProduct<'a> {
+impl<'a, T> CartesianProduct<'a, T>
+where
+    T: OptFloat,
+{
     /// Construct new instance of Cartesian product of constraints
     ///
     /// # Note
@@ -116,7 +122,7 @@ impl<'a> CartesianProduct<'a> {
     /// ```
     /// The method will panic if any of the associated projections panics.
     ///
-    pub fn add_constraint(mut self, ni: usize, constraint: impl Constraint + 'a) -> Self {
+    pub fn add_constraint(mut self, ni: usize, constraint: impl Constraint<T> + 'a) -> Self {
         assert!(
             self.dimension() < ni,
             "provided index is smaller than or equal to previous index, or zero"
@@ -127,7 +133,10 @@ impl<'a> CartesianProduct<'a> {
     }
 }
 
-impl<'a> Constraint for CartesianProduct<'a> {
+impl<'a, T> Constraint<T> for CartesianProduct<'a, T>
+where
+    T: OptFloat,
+{
     /// Project onto Cartesian product of constraints
     ///
     /// The given vector `x` is updated with the projection on the set
@@ -136,7 +145,7 @@ impl<'a> Constraint for CartesianProduct<'a> {
     ///
     /// The method will panic if the dimension of `x` is not equal to the
     /// dimension of the Cartesian product (see `dimension()`)
-    fn project(&self, x: &mut [f64]) {
+    fn project(&self, x: &mut [T]) {
         assert!(x.len() == self.dimension(), "x has wrong size");
         let mut j = 0;
         self.idx

--- a/src/constraints/finite.rs
+++ b/src/constraints/finite.rs
@@ -1,17 +1,23 @@
 use super::Constraint;
-
+use crate::core::OptFloat;
 ///
 /// A finite set, $X = \\{x_1, x_2, \ldots, x_n\\}\subseteq\mathbb{R}^n$, given vectors
 /// $x_i\in\mathbb{R}^n$
 ///
 #[derive(Clone, Copy)]
-pub struct FiniteSet<'a> {
+pub struct FiniteSet<'a, T>
+where
+    T: OptFloat,
+{
     /// The data is stored in a Vec-of-Vec datatype, that is, a vector
     /// of vectors
-    data: &'a [&'a [f64]],
+    data: &'a [&'a [T]],
 }
 
-impl<'a> FiniteSet<'a> {
+impl<'a, T> FiniteSet<'a, T>
+where
+    T: OptFloat,
+{
     /// Construct a finite set, $X = \\{x_1, x_2, \ldots, x_n\\}$, given vectors
     /// $x_i\in\mathbb{R}^n$
     ///
@@ -41,7 +47,7 @@ impl<'a> FiniteSet<'a> {
     /// This method will panic if (i) the given vector of data is empty
     /// and (ii) if the given vectors have unequal dimensions.
     ///
-    pub fn new(data: &'a [&'a [f64]]) -> Self {
+    pub fn new(data: &'a [&'a [T]]) -> Self {
         // Do a sanity check...
         assert!(!data.is_empty(), "empty data not allowed");
         let n = data[0].len();
@@ -52,7 +58,10 @@ impl<'a> FiniteSet<'a> {
     }
 }
 
-impl<'a> Constraint for FiniteSet<'a> {
+impl<'a, T> Constraint<T> for FiniteSet<'a, T>
+where
+    T: OptFloat + std::ops::AddAssign,
+{
     ///
     /// Projection on the current finite set
     ///
@@ -84,9 +93,9 @@ impl<'a> Constraint for FiniteSet<'a> {
     ///
     /// Does not panic
     ///
-    fn project(&self, x: &mut [f64]) {
+    fn project(&self, x: &mut [T]) {
         let mut idx: usize = 0;
-        let mut best_distance: f64 = num::Float::infinity();
+        let mut best_distance: T = T::infinity();
         for (i, v) in self.data.iter().enumerate() {
             let dist = crate::matrix_operations::norm2_squared_diff(v, x);
             if dist < best_distance {

--- a/src/constraints/halfspace.rs
+++ b/src/constraints/halfspace.rs
@@ -1,18 +1,25 @@
 use super::Constraint;
+use crate::core::OptFloat;
 use crate::matrix_operations;
 
 #[derive(Clone)]
 /// A halfspace is a set given by $H = \\{x \in \mathbb{R}^n {}:{} \langle c, x\rangle \leq b\\}$.
-pub struct Halfspace<'a> {
+pub struct Halfspace<'a, T>
+where
+    T: OptFloat,
+{
     /// normal vector
-    normal_vector: &'a [f64],
+    normal_vector: &'a [T],
     /// offset
-    offset: f64,
+    offset: T,
     /// squared Euclidean norm of the normal vector (computed once upon construction)
-    normal_vector_squared_norm: f64,
+    normal_vector_squared_norm: T,
 }
 
-impl<'a> Halfspace<'a> {
+impl<'a, T> Halfspace<'a, T>
+where
+    T: OptFloat,
+{
     /// A halfspace is a set given by $H = \\{x \in \mathbb{R}^n {}:{} \langle c, x\rangle \leq b\\}$,
     /// where $c$ is the normal vector of the halfspace and $b$ is an offset.
     ///
@@ -45,7 +52,7 @@ impl<'a> Halfspace<'a> {
     /// halfspace.project(&mut x);
     /// ```
     ///
-    pub fn new(normal_vector: &'a [f64], offset: f64) -> Self {
+    pub fn new(normal_vector: &'a [T], offset: T) -> Self {
         let normal_vector_squared_norm = matrix_operations::norm2_squared(normal_vector);
         Halfspace {
             normal_vector,
@@ -55,7 +62,10 @@ impl<'a> Halfspace<'a> {
     }
 }
 
-impl<'a> Constraint for Halfspace<'a> {
+impl<'a, T> Constraint<T> for Halfspace<'a, T>
+where
+    T: OptFloat + std::ops::SubAssign,
+{
     /// Projects on halfspace using the following formula:
     ///
     /// $$\begin{aligned}
@@ -79,13 +89,13 @@ impl<'a> Constraint for Halfspace<'a> {
     /// This method panics if the length of `x` is not equal to the dimension
     /// of the halfspace.
     ///
-    fn project(&self, x: &mut [f64]) {
+    fn project(&self, x: &mut [T]) {
         let inner_product = matrix_operations::inner_product(x, self.normal_vector);
         if inner_product > self.offset {
             let factor = (inner_product - self.offset) / self.normal_vector_squared_norm;
             x.iter_mut()
                 .zip(self.normal_vector.iter())
-                .for_each(|(x, normal_vector_i)| *x -= factor * normal_vector_i);
+                .for_each(|(x, normal_vector_i)| *x -= factor * *normal_vector_i);
         }
     }
 

--- a/src/constraints/hyperplane.rs
+++ b/src/constraints/hyperplane.rs
@@ -1,18 +1,25 @@
 use super::Constraint;
+use crate::core::OptFloat;
 use crate::matrix_operations;
 
 #[derive(Clone)]
 /// A hyperplane is a set given by $H = \\{x \in \mathbb{R}^n {}:{} \langle c, x\rangle = b\\}$.
-pub struct Hyperplane<'a> {
+pub struct Hyperplane<'a, T>
+where
+    T: OptFloat,
+{
     /// normal vector
-    normal_vector: &'a [f64],
+    normal_vector: &'a [T],
     /// offset
-    offset: f64,
+    offset: T,
     /// squared Euclidean norm of the normal vector (computed once upon construction)
-    normal_vector_squared_norm: f64,
+    normal_vector_squared_norm: T,
 }
 
-impl<'a> Hyperplane<'a> {
+impl<'a, T> Hyperplane<'a, T>
+where
+    T: OptFloat,
+{
     /// A hyperplane is a set given by $H = \\{x \in \mathbb{R}^n {}:{} \langle c, x\rangle = b\\}$,
     /// where $c$ is the normal vector of the hyperplane and $b$ is an offset.
     ///
@@ -45,7 +52,7 @@ impl<'a> Hyperplane<'a> {
     /// hyperplane.project(&mut x);
     /// ```
     ///
-    pub fn new(normal_vector: &'a [f64], offset: f64) -> Self {
+    pub fn new(normal_vector: &'a [T], offset: T) -> Self {
         let normal_vector_squared_norm = matrix_operations::norm2_squared(normal_vector);
         Hyperplane {
             normal_vector,
@@ -55,7 +62,10 @@ impl<'a> Hyperplane<'a> {
     }
 }
 
-impl<'a> Constraint for Hyperplane<'a> {
+impl<'a, T> Constraint<T> for Hyperplane<'a, T>
+where
+    T: OptFloat + std::ops::SubAssign,
+{
     /// Projects on the hyperplane using the formula:
     ///
     /// $$\begin{aligned}
@@ -76,12 +86,12 @@ impl<'a> Constraint for Hyperplane<'a> {
     /// This method panics if the length of `x` is not equal to the dimension
     /// of the hyperplane.
     ///
-    fn project(&self, x: &mut [f64]) {
+    fn project(&self, x: &mut [T]) {
         let inner_product = matrix_operations::inner_product(x, self.normal_vector);
         let factor = (inner_product - self.offset) / self.normal_vector_squared_norm;
         x.iter_mut()
             .zip(self.normal_vector.iter())
-            .for_each(|(x, nrm_vct)| *x -= factor * nrm_vct);
+            .for_each(|(x, nrm_vct)| *x -= factor * *nrm_vct);
     }
 
     /// Hyperplanes are convex sets

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -40,11 +40,16 @@ pub use soc::SecondOrderCone;
 pub use sphere2::Sphere2;
 pub use zero::Zero;
 
+use crate::core::OptFloat;
+
 /// A set which can be used as a constraint
 ///
 /// This trait defines an abstract function that allows to compute projections
 /// on sets; this is implemented by a series of structures (see below for details)
-pub trait Constraint {
+pub trait Constraint<T>
+where
+    T: OptFloat,
+{
     /// Projection onto the set, that is,
     ///
     /// $$
@@ -55,7 +60,7 @@ pub trait Constraint {
     ///
     /// - `x`: The given vector $x$ is updated with the projection on the set
     ///
-    fn project(&self, x: &mut [f64]);
+    fn project(&self, x: &mut [T]);
 
     /// Returns true if and only if the set is convex
     fn is_convex(&self) -> bool;

--- a/src/constraints/no_constraints.rs
+++ b/src/constraints/no_constraints.rs
@@ -1,5 +1,5 @@
 use super::Constraint;
-
+use crate::core::OptFloat;
 /// The whole space, no constraints
 #[derive(Default, Clone, Copy)]
 pub struct NoConstraints {}
@@ -12,8 +12,11 @@ impl NoConstraints {
     }
 }
 
-impl Constraint for NoConstraints {
-    fn project(&self, _x: &mut [f64]) {}
+impl<T> Constraint<T> for NoConstraints
+where
+    T: OptFloat,
+{
+    fn project(&self, _x: &mut [T]) {}
 
     fn is_convex(&self) -> bool {
         true

--- a/src/constraints/rectangle.rs
+++ b/src/constraints/rectangle.rs
@@ -1,5 +1,5 @@
 use super::Constraint;
-
+use crate::core::OptFloat;
 #[derive(Clone, Copy)]
 ///
 /// A rectangle, $R = \\{x \in \mathbb{R}^n {}:{} x_{\min} {}\leq{} x {}\leq{} x_{\max}\\}$
@@ -7,12 +7,18 @@ use super::Constraint;
 /// A set of the form $\\{x \in \mathbb{R}^n {}:{} x_{\min} {}\leq{} x {}\leq{} x_{\max}\\}$,
 /// where $\leq$ is meant in the element-wise sense and either of $x_{\min}$ and $x_{\max}$ can
 /// be equal to infinity.
-pub struct Rectangle<'a> {
-    xmin: Option<&'a [f64]>,
-    xmax: Option<&'a [f64]>,
+pub struct Rectangle<'a, T>
+where
+    T: OptFloat,
+{
+    xmin: Option<&'a [T]>,
+    xmax: Option<&'a [T]>,
 }
 
-impl<'a> Rectangle<'a> {
+impl<'a, T> Rectangle<'a, T>
+where
+    T: OptFloat,
+{
     /// Construct a new rectangle with given $x_{\min}$ and $x_{\max}$
     ///
     /// # Arguments
@@ -34,7 +40,7 @@ impl<'a> Rectangle<'a> {
     /// - Both `xmin` and `xmax` have been provided, but they have incompatible
     ///   dimensions
     ///
-    pub fn new(xmin: Option<&'a [f64]>, xmax: Option<&'a [f64]>) -> Self {
+    pub fn new(xmin: Option<&'a [T]>, xmax: Option<&'a [T]>) -> Self {
         assert!(xmin.is_some() || xmax.is_some()); // xmin or xmax must be Some
         assert!(
             xmin.is_none() || xmax.is_none() || xmin.unwrap().len() == xmax.unwrap().len(),
@@ -44,8 +50,11 @@ impl<'a> Rectangle<'a> {
     }
 }
 
-impl<'a> Constraint for Rectangle<'a> {
-    fn project(&self, x: &mut [f64]) {
+impl<'a, T> Constraint<T> for Rectangle<'a, T>
+where
+    T: OptFloat,
+{
+    fn project(&self, x: &mut [T]) {
         if let Some(xmin) = &self.xmin {
             x.iter_mut().zip(xmin.iter()).for_each(|(x_, xmin_)| {
                 if *x_ < *xmin_ {

--- a/src/constraints/simplex.rs
+++ b/src/constraints/simplex.rs
@@ -1,49 +1,59 @@
 use super::Constraint;
-
+use crate::core::OptFloat;
 #[derive(Copy, Clone)]
 /// A simplex with level $\alpha$ is a set of the form
 /// $\Delta_\alpha^n = \\{x \in \mathbb{R}^n {}:{} x \geq 0, \sum_i x_i = \alpha\\}$,
 /// where $\alpha$ is a positive constant.
-pub struct Simplex {
+pub struct Simplex<T>
+where
+    T: OptFloat,
+{
     /// Simplex level
-    alpha: f64,
+    alpha: T,
 }
 
-impl Simplex {
+impl<T> Simplex<T>
+where
+    T: OptFloat,
+{
     /// Construct a new simplex with given (positive) $\alpha$. The user does not need
     /// to specify the dimension of the simplex.
-    pub fn new(alpha: f64) -> Self {
-        assert!(alpha > 0.0, "alpha is nonpositive");
+    pub fn new(alpha: T) -> Self {
+        assert!(alpha > T::zero(), "alpha is nonpositive");
         Simplex { alpha }
     }
 }
 
-impl Constraint for Simplex {
+impl<T> Constraint<T> for Simplex<T>
+where
+    T: OptFloat + PartialOrd + Copy + num::FromPrimitive,
+{
     /// Project onto $\Delta_\alpha^n$ using Condat's fast projection algorithm.
     ///
     /// See: Laurent Condat. Fast Projection onto the Simplex and the $\ell_1$ Ball.
     /// <em>Mathematical Programming, Series A,</em> Springer, 2016, 158 (1), pp.575-585.
     /// ⟨<a href="https://dx.doi.org/10.1007/s10107-015-0946-6">10.1007/s10107-015-0946-6</a>⟩.
-    fn project(&self, x: &mut [f64]) {
+    fn project(&self, x: &mut [T]) {
         let a = &self.alpha;
 
         // ---- step 1
-        let mut v = Vec::<f64>::with_capacity(x.len()); // vector containing x[0]
+        let mut v = Vec::<T>::with_capacity(x.len()); // vector containing x[0]
         v.push(x[0]);
         let mut v_size_old: i64 = -1; // 64 bit signed int
-        let mut v_tilde: Vec<f64> = Vec::new(); // empty vector of f64
-        let mut rho: f64 = x[0] - a; // 64 bit float
+        let mut v_tilde: Vec<T> = Vec::new(); // empty vector of T
+        let mut rho: T = x[0] - *a; // T float
 
         // ---- step 2
         x.iter().skip(1).for_each(|x_n| {
             if *x_n > rho {
-                rho += (*x_n - rho) / ((v.len() + 1) as f64);
-                if rho > *x_n - a {
+                let len_plus_one = T::from(v.len() + 1).unwrap();
+                rho = rho + (*x_n - rho) / len_plus_one;
+                if rho > *x_n - *a {
                     v.push(*x_n);
                 } else {
                     v_tilde.extend(&v);
                     v = vec![*x_n];
-                    rho = *x_n - a;
+                    rho = *x_n - *a;
                 }
             }
         });
@@ -53,7 +63,8 @@ impl Constraint for Simplex {
             v_tilde.iter().for_each(|v_t_n| {
                 if *v_t_n > rho {
                     v.push(*v_t_n);
-                    rho += (*v_t_n - rho) / (v.len() as f64);
+                    let len_t = T::from(v.len()).unwrap();
+                    rho = rho + (*v_t_n - rho) / len_t;
                 }
             });
         }
@@ -67,7 +78,8 @@ impl Constraint for Simplex {
                 if *v_n <= rho {
                     hit_list.push(n);
                     current_len_v -= 1;
-                    rho += (rho - *v_n) / (current_len_v as f64);
+                    let current_len_t = T::from(current_len_v).unwrap();
+                    rho = rho + (rho - *v_n) / current_len_t;
                 }
             });
             hit_list.iter().rev().for_each(|target| {
@@ -79,7 +91,7 @@ impl Constraint for Simplex {
         }
 
         // ---- step 6
-        let zero: f64 = 0.0;
+        let zero: T = T::zero();
         x.iter_mut().for_each(|x_n| *x_n = zero.max(*x_n - rho));
     }
 

--- a/src/constraints/sphere2.rs
+++ b/src/constraints/sphere2.rs
@@ -1,23 +1,32 @@
 use super::Constraint;
-
+use crate::core::OptFloat;
 #[derive(Copy, Clone)]
 /// A Euclidean sphere, that is, a set given by $S_2^r = \\{x \in \mathbb{R}^n {}:{} \Vert{}x{}\Vert = r\\}$
 /// or a Euclidean sphere centered at a point $x_c$, that is, $S_2^{x_c, r} = \\{x \in \mathbb{R}^n {}:{} \Vert{}x-x_c{}\Vert = r\\}$
-pub struct Sphere2<'a> {
-    center: Option<&'a [f64]>,
-    radius: f64,
+pub struct Sphere2<'a, T>
+where
+    T: OptFloat,
+{
+    center: Option<&'a [T]>,
+    radius: T,
 }
 
-impl<'a> Sphere2<'a> {
+impl<'a, T> Sphere2<'a, T>
+where
+    T: OptFloat,
+{
     /// Construct a new Euclidean sphere with given center and radius
     /// If no `center` is given, then it is assumed to be in the origin
-    pub fn new(center: Option<&'a [f64]>, radius: f64) -> Self {
-        assert!(radius > 0.0);
+    pub fn new(center: Option<&'a [T]>, radius: T) -> Self {
+        assert!(radius > T::zero());
         Sphere2 { center, radius }
     }
 }
 
-impl<'a> Constraint for Sphere2<'a> {
+impl<'a, T> Constraint<T> for Sphere2<'a, T>
+where
+    T: OptFloat,
+{
     /// Projection onto the sphere, $S_{r, c}$ with radius $r$ and center $c$.
     /// If $x\neq c$, the projection is uniquely defined by
     ///
@@ -33,8 +42,8 @@ impl<'a> Constraint for Sphere2<'a> {
     ///
     /// - `x`: The given vector $x$ is updated with the projection on the set
     ///
-    fn project(&self, x: &mut [f64]) {
-        let epsilon = 1e-12;
+    fn project(&self, x: &mut [T]) {
+        let epsilon = T::from(1e-12).unwrap();
         if let Some(center) = &self.center {
             let norm_difference = crate::matrix_operations::norm2_squared_diff(x, center).sqrt();
             if norm_difference <= epsilon {
@@ -52,7 +61,7 @@ impl<'a> Constraint for Sphere2<'a> {
                 return;
             }
             let norm_over_radius = self.radius / norm_x;
-            x.iter_mut().for_each(|x_| *x_ *= norm_over_radius);
+            x.iter_mut().for_each(|x_| *x_ = *x_ * norm_over_radius);
         }
     }
 

--- a/src/constraints/tests.rs
+++ b/src/constraints/tests.rs
@@ -1,7 +1,6 @@
-use crate::matrix_operations;
+use rand;
 
 use super::*;
-use rand;
 
 #[test]
 fn t_zero_set() {
@@ -268,7 +267,7 @@ fn t_ball2_at_origin_different_radius_inside() {
 
 #[test]
 fn t_ball2_at_center_different_radius_outside() {
-    let radius = 1.2;
+    let radius = 1.2_f64;
     let mut x = [1.0, 1.0];
     let center = [-0.8, -1.1];
     let ball = Ball2::new(Some(&center), radius);
@@ -430,7 +429,7 @@ fn t_second_order_cone_case_ii() {
 
 #[test]
 fn t_second_order_cone_case_iii() {
-    let alpha = 1.5;
+    let alpha = 1.5_f64;
     let soc = SecondOrderCone::new(alpha);
     let mut x = vec![1.0, 1.0, 0.1];
     soc.project(&mut x);
@@ -615,7 +614,7 @@ fn t_is_convex_soc() {
 #[test]
 fn t_is_convex_zero() {
     let zero = Zero::new();
-    assert!(zero.is_convex());
+    assert!(<Zero as Constraint<f64>>::is_convex(&zero));
 }
 
 #[test]
@@ -897,7 +896,7 @@ fn t_epigraph_squared_norm() {
         let t = 0.01 * i as f64;
         let mut x = [1., 2., 3., t];
         epi.project(&mut x);
-        let err = (matrix_operations::norm2_squared(&x[..3]) - x[3]).abs();
+        let err = (crate::matrix_operations::norm2_squared(&x[..3]) - x[3]).abs();
         assert!(err < 1e-10, "wrong projection on epigraph of squared norm");
     }
 }
@@ -987,5 +986,5 @@ fn t_affine_space_single_row() {
 fn t_affine_space_wrong_dimensions() {
     let a = vec![0.5, 0.1, 0.2, -0.3, -0.6, 0.3, 0., 0.5, 1.0, 0.1, -1.0];
     let b = vec![1., 2., -0.5];
-    let _ = AffineSpace::new(a, b);
+    let _: AffineSpace<f64> = AffineSpace::new(a, b);
 }

--- a/src/constraints/zero.rs
+++ b/src/constraints/zero.rs
@@ -1,5 +1,5 @@
 use super::Constraint;
-
+use crate::core::OptFloat;
 #[derive(Clone, Copy, Default)]
 /// Set Zero, $\\{0\\}$
 pub struct Zero {}
@@ -11,11 +11,14 @@ impl Zero {
     }
 }
 
-impl Constraint for Zero {
+impl<T> Constraint<T> for Zero
+where
+    T: OptFloat,
+{
     /// Computes the projection on $\\{0\\}$, that is, $\Pi_{\\{0\\}}(x) = 0$
     /// for all $x$
-    fn project(&self, x: &mut [f64]) {
-        x.iter_mut().for_each(|xi| *xi = 0.0);
+    fn project(&self, x: &mut [T]) {
+        x.iter_mut().for_each(|xi| *xi = T::zero());
     }
 
     fn is_convex(&self) -> bool {

--- a/src/core/fbs/fbs_cache.rs
+++ b/src/core/fbs/fbs_cache.rs
@@ -2,18 +2,26 @@
 //!
 use std::num::NonZeroUsize;
 
+use crate::core::OptFloat;
+
 /// Cache for the forward-backward splitting (FBS), or projected gradient, algorithm
 ///
 /// This struct allocates memory needed for the FBS algorithm
-pub struct FBSCache {
-    pub(crate) work_gradient_u: Vec<f64>,
-    pub(crate) work_u_previous: Vec<f64>,
-    pub(crate) gamma: f64,
-    pub(crate) tolerance: f64,
-    pub(crate) norm_fpr: f64,
+pub struct FBSCache<T>
+where
+    T: OptFloat,
+{
+    pub(crate) work_gradient_u: Vec<T>,
+    pub(crate) work_u_previous: Vec<T>,
+    pub(crate) gamma: T,
+    pub(crate) tolerance: T,
+    pub(crate) norm_fpr: T,
 }
 
-impl FBSCache {
+impl<T> FBSCache<T>
+where
+    T: OptFloat,
+{
     /// Construct a new instance of `FBSCache`
     ///
     /// ## Arguments
@@ -37,13 +45,13 @@ impl FBSCache {
     /// This method will panic if there is no available memory for the required allocation
     /// (capacity overflow)
     ///
-    pub fn new(n: NonZeroUsize, gamma: f64, tolerance: f64) -> FBSCache {
+    pub fn new(n: NonZeroUsize, gamma: T, tolerance: T) -> FBSCache<T> {
         FBSCache {
-            work_gradient_u: vec![0.0; n.get()],
-            work_u_previous: vec![0.0; n.get()],
+            work_gradient_u: vec![T::zero(); n.get()],
+            work_u_previous: vec![T::zero(); n.get()],
             gamma,
             tolerance,
-            norm_fpr: std::f64::INFINITY,
+            norm_fpr: T::infinity(),
         }
     }
 }

--- a/src/core/fbs/tests.rs
+++ b/src/core/fbs/tests.rs
@@ -1,8 +1,9 @@
+use std::num::NonZeroUsize;
+
 use super::super::*;
 use super::*;
 use crate::constraints;
 use crate::core::fbs::fbs_engine::FBSEngine;
-use std::num::NonZeroUsize;
 
 const N_DIM: usize = 2;
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,11 +4,13 @@
 //!
 
 pub mod fbs;
+pub mod opt_float;
 pub mod panoc;
 pub mod problem;
 pub mod solver_status;
 
 pub use crate::{constraints, FunctionCallResult, SolverError};
+pub use opt_float::OptFloat;
 pub use problem::Problem;
 pub use solver_status::SolverStatus;
 
@@ -29,12 +31,15 @@ pub enum ExitStatus {
 }
 
 /// A general optimizer
-pub trait Optimizer {
+pub trait Optimizer<T>
+where
+    T: OptFloat + std::fmt::Debug,
+{
     /// solves a given problem and updates the initial estimate `u` with the solution
     ///
     /// Returns the solver status
     ///
-    fn solve(&mut self, u: &mut [f64]) -> Result<SolverStatus, SolverError>;
+    fn solve(&mut self, u: &mut [T]) -> Result<SolverStatus<T>, SolverError>;
 }
 
 /// Engine supporting an algorithm
@@ -46,10 +51,13 @@ pub trait Optimizer {
 /// It defines what the algorithm does at every step (see `step`) and whether
 /// the specified termination criterion is satisfied
 ///
-pub trait AlgorithmEngine {
+pub trait AlgorithmEngine<T>
+where
+    T: OptFloat + std::fmt::Debug,
+{
     /// Take a step of the algorithm and return `Ok(true)` only if the iterations should continue
-    fn step(&mut self, u: &mut [f64]) -> Result<bool, SolverError>;
+    fn step(&mut self, u: &mut [T]) -> Result<bool, SolverError>;
 
     /// Initializes the algorithm
-    fn init(&mut self, u: &mut [f64]) -> FunctionCallResult;
+    fn init(&mut self, u: &mut [T]) -> FunctionCallResult;
 }

--- a/src/core/opt_float.rs
+++ b/src/core/opt_float.rs
@@ -1,0 +1,113 @@
+//! OptFloat trait that combines Float functionality with optimization constants (and a few traits)
+use num::Float;
+
+/// Trait that combines Float functionality with optimization-specific constants
+/// This allows different float types to have different optimization parameters
+pub trait OptFloat:
+    Float
+    + std::iter::Sum<Self>
+    + num::FromPrimitive
+    + num::ToPrimitive
+    + std::fmt::Debug
+    + std::ops::AddAssign
+    + std::ops::SubAssign
+    + std::ops::MulAssign
+    + std::ops::DivAssign
+{
+    /// Minimum estimated Lipschitz constant (initial estimate)
+    fn min_l_estimate() -> Self;
+
+    /// gamma = GAMMA_L_COEFF/L
+    fn gamma_l_coeff() -> Self;
+
+    /// Delta in the estimation of the initial Lipschitz constant
+    fn delta_lipschitz() -> Self;
+
+    /// Epsilon in the estimation of the initial Lipschitz constant
+    fn epsilon_lipschitz() -> Self;
+
+    /// Safety parameter used to check a strict inequality in the update of the Lipschitz constant
+    fn lipschitz_update_epsilon() -> Self;
+
+    /// Maximum possible Lipschitz constant
+    fn max_lipschitz_constant() -> Self;
+}
+
+/// Default implementation for f64 with original constants
+impl OptFloat for f64 {
+    fn min_l_estimate() -> Self {
+        1e-10
+    }
+
+    fn gamma_l_coeff() -> Self {
+        0.95
+    }
+
+    fn delta_lipschitz() -> Self {
+        1e-12
+    }
+
+    fn epsilon_lipschitz() -> Self {
+        1e-6
+    }
+
+    fn lipschitz_update_epsilon() -> Self {
+        1e-6
+    }
+
+    fn max_lipschitz_constant() -> Self {
+        1e9
+    }
+}
+
+/// Default implementation for f32 with scaled constants
+impl OptFloat for f32 {
+    fn min_l_estimate() -> Self {
+        8.74e-6
+    }
+
+    fn gamma_l_coeff() -> Self {
+        0.95
+    }
+
+    fn delta_lipschitz() -> Self {
+        1.32e-6
+    }
+
+    fn epsilon_lipschitz() -> Self {
+        7.32e-4
+    }
+
+    fn lipschitz_update_epsilon() -> Self {
+        2.62e-4
+    }
+
+    fn max_lipschitz_constant() -> Self {
+        1e9
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_f64_constants() {
+        assert_eq!(f64::min_l_estimate(), 1e-10);
+        assert_eq!(f64::gamma_l_coeff(), 0.95);
+        assert_eq!(f64::delta_lipschitz(), 1e-12);
+        assert_eq!(f64::epsilon_lipschitz(), 1e-6);
+        assert_eq!(f64::lipschitz_update_epsilon(), 1e-6);
+        assert_eq!(f64::max_lipschitz_constant(), 1e9);
+    }
+
+    #[test]
+    fn test_f32_constants() {
+        assert_eq!(f32::min_l_estimate(), 8.74e-6);
+        assert_eq!(f32::gamma_l_coeff(), 0.95);
+        assert_eq!(f32::delta_lipschitz(), 1.32e-6);
+        assert_eq!(f32::epsilon_lipschitz(), 7.32e-4);
+        assert_eq!(f32::lipschitz_update_epsilon(), 2.62e-4);
+        assert_eq!(f32::max_lipschitz_constant(), 1e9);
+    }
+}

--- a/src/core/panoc/mod.rs
+++ b/src/core/panoc/mod.rs
@@ -11,3 +11,6 @@ pub use panoc_optimizer::PANOCOptimizer;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod tests_f32;

--- a/src/core/panoc/panoc_cache.rs
+++ b/src/core/panoc/panoc_cache.rs
@@ -1,3 +1,5 @@
+use crate::core::OptFloat;
+
 const DEFAULT_SY_EPSILON: f64 = 1e-10;
 const DEFAULT_CBFGS_EPSILON: f64 = 1e-8;
 const DEFAULT_CBFGS_ALPHA: f64 = 1.0;
@@ -12,32 +14,38 @@ const DEFAULT_CBFGS_ALPHA: f64 = 1.0;
 /// Subsequently, a `PANOCEngine` is used to construct an instance of `PANOCAlgorithm`
 ///
 #[derive(Debug)]
-pub struct PANOCCache {
-    pub(crate) lbfgs: lbfgs::Lbfgs,
-    pub(crate) gradient_u: Vec<f64>,
+pub struct PANOCCache<T>
+where
+    T: OptFloat,
+{
+    pub(crate) lbfgs: lbfgs::Lbfgs<T>,
+    pub(crate) gradient_u: Vec<T>,
     /// Stores the gradient of the cost at the previous iteration. This is
     /// an optional field because it is used (and needs to be allocated)
     /// only if we need to check the AKKT-specific termination conditions
-    pub(crate) gradient_u_previous: Option<Vec<f64>>,
-    pub(crate) u_half_step: Vec<f64>,
-    pub(crate) gradient_step: Vec<f64>,
-    pub(crate) direction_lbfgs: Vec<f64>,
-    pub(crate) u_plus: Vec<f64>,
-    pub(crate) rhs_ls: f64,
-    pub(crate) lhs_ls: f64,
-    pub(crate) gamma_fpr: Vec<f64>,
-    pub(crate) gamma: f64,
-    pub(crate) tolerance: f64,
-    pub(crate) norm_gamma_fpr: f64,
-    pub(crate) tau: f64,
-    pub(crate) lipschitz_constant: f64,
-    pub(crate) sigma: f64,
-    pub(crate) cost_value: f64,
+    pub(crate) gradient_u_previous: Option<Vec<T>>,
+    pub(crate) u_half_step: Vec<T>,
+    pub(crate) gradient_step: Vec<T>,
+    pub(crate) direction_lbfgs: Vec<T>,
+    pub(crate) u_plus: Vec<T>,
+    pub(crate) rhs_ls: T,
+    pub(crate) lhs_ls: T,
+    pub(crate) gamma_fpr: Vec<T>,
+    pub(crate) gamma: T,
+    pub(crate) tolerance: T,
+    pub(crate) norm_gamma_fpr: T,
+    pub(crate) tau: T,
+    pub(crate) lipschitz_constant: T,
+    pub(crate) sigma: T,
+    pub(crate) cost_value: T,
     pub(crate) iteration: usize,
-    pub(crate) akkt_tolerance: Option<f64>,
+    pub(crate) akkt_tolerance: Option<T>,
 }
 
-impl PANOCCache {
+impl<T> PANOCCache<T>
+where
+    T: OptFloat,
+{
     /// Construct a new instance of `PANOCCache`
     ///
     /// ## Arguments
@@ -59,30 +67,30 @@ impl PANOCCache {
     ///
     /// It allocates a total of `8*problem_size + 2*lbfgs_memory_size*problem_size + 2*lbfgs_memory_size + 11` floats (`f64`)
     ///
-    pub fn new(problem_size: usize, tolerance: f64, lbfgs_memory_size: usize) -> PANOCCache {
-        assert!(tolerance > 0., "tolerance must be positive");
+    pub fn new(problem_size: usize, tolerance: T, lbfgs_memory_size: usize) -> PANOCCache<T> {
+        assert!(tolerance > T::zero(), "tolerance must be positive");
 
         PANOCCache {
-            gradient_u: vec![0.0; problem_size],
+            gradient_u: vec![T::zero(); problem_size],
             gradient_u_previous: None,
-            u_half_step: vec![0.0; problem_size],
-            gamma_fpr: vec![0.0; problem_size],
-            direction_lbfgs: vec![0.0; problem_size],
-            gradient_step: vec![0.0; problem_size],
-            u_plus: vec![0.0; problem_size],
-            gamma: 0.0,
+            u_half_step: vec![T::zero(); problem_size],
+            gamma_fpr: vec![T::zero(); problem_size],
+            direction_lbfgs: vec![T::zero(); problem_size],
+            gradient_step: vec![T::zero(); problem_size],
+            u_plus: vec![T::zero(); problem_size],
+            gamma: T::zero(),
             tolerance,
-            norm_gamma_fpr: std::f64::INFINITY,
-            lbfgs: lbfgs::Lbfgs::new(problem_size, lbfgs_memory_size)
-                .with_cbfgs_alpha(DEFAULT_CBFGS_ALPHA)
-                .with_cbfgs_epsilon(DEFAULT_CBFGS_EPSILON)
-                .with_sy_epsilon(DEFAULT_SY_EPSILON),
-            lhs_ls: 0.0,
-            rhs_ls: 0.0,
-            tau: 1.0,
-            lipschitz_constant: 0.0,
-            sigma: 0.0,
-            cost_value: 0.0,
+            norm_gamma_fpr: T::infinity(),
+            lbfgs: lbfgs::Lbfgs::<T>::new(problem_size, lbfgs_memory_size)
+                .with_cbfgs_alpha(T::from(DEFAULT_CBFGS_ALPHA).unwrap())
+                .with_cbfgs_epsilon(T::from(DEFAULT_CBFGS_EPSILON).unwrap())
+                .with_sy_epsilon(T::from(DEFAULT_SY_EPSILON).unwrap()),
+            lhs_ls: T::zero(),
+            rhs_ls: T::zero(),
+            tau: T::one(),
+            lipschitz_constant: T::zero(),
+            sigma: T::zero(),
+            cost_value: T::zero(),
             iteration: 0,
             akkt_tolerance: None,
         }
@@ -99,10 +107,13 @@ impl PANOCCache {
     ///
     /// The method panics if `akkt_tolerance` is nonpositive
     ///
-    pub fn set_akkt_tolerance(&mut self, akkt_tolerance: f64) {
-        assert!(akkt_tolerance > 0.0, "akkt_tolerance must be positive");
+    pub fn set_akkt_tolerance(&mut self, akkt_tolerance: T) {
+        assert!(
+            akkt_tolerance > T::zero(),
+            "akkt_tolerance must be positive"
+        );
         self.akkt_tolerance = Some(akkt_tolerance);
-        self.gradient_u_previous = Some(vec![0.0; self.gradient_step.len()]);
+        self.gradient_u_previous = Some(vec![T::zero(); self.gradient_step.len()]);
     }
 
     /// Copies the value of the current cost gradient to `gradient_u_previous`,
@@ -117,8 +128,8 @@ impl PANOCCache {
     }
 
     /// Computes the AKKT residual which is defined as `||gamma*(fpr + df - df_previous)||`
-    fn akkt_residual(&self) -> f64 {
-        let mut r = 0.0;
+    fn akkt_residual(&self) -> T {
+        let mut r = T::zero();
         if let Some(df_previous) = &self.gradient_u_previous {
             // Notation: gamma_fpr_i is the i-th element of gamma_fpr = gamma * fpr,
             // df_i is the i-th element of the gradient of the cost function at the
@@ -129,7 +140,7 @@ impl PANOCCache {
                 .iter()
                 .zip(self.gradient_u.iter())
                 .zip(df_previous.iter())
-                .fold(0.0, |mut sum, ((&gamma_fpr_i, &df_i), &dfp_i)| {
+                .fold(T::zero(), |mut sum, ((&gamma_fpr_i, &df_i), &dfp_i)| {
                     sum += (gamma_fpr_i + self.gamma * (df_i - dfp_i)).powi(2);
                     sum
                 })
@@ -175,14 +186,14 @@ impl PANOCCache {
     ///   and `gamma` to 0.0
     pub fn reset(&mut self) {
         self.lbfgs.reset();
-        self.lhs_ls = 0.0;
-        self.rhs_ls = 0.0;
-        self.tau = 1.0;
-        self.lipschitz_constant = 0.0;
-        self.sigma = 0.0;
-        self.cost_value = 0.0;
+        self.lhs_ls = T::zero();
+        self.rhs_ls = T::zero();
+        self.tau = T::one();
+        self.lipschitz_constant = T::zero();
+        self.sigma = T::zero();
+        self.cost_value = T::zero();
         self.iteration = 0;
-        self.gamma = 0.0;
+        self.gamma = T::zero();
     }
 
     /// Sets the CBFGS parameters `alpha` and `epsilon`
@@ -202,7 +213,7 @@ impl PANOCCache {
     /// The method panics if alpha or epsilon are nonpositive and if sy_epsilon
     /// is negative.
     ///
-    pub fn with_cbfgs_parameters(mut self, alpha: f64, epsilon: f64, sy_epsilon: f64) -> Self {
+    pub fn with_cbfgs_parameters(mut self, alpha: T, epsilon: T, sy_epsilon: T) -> Self {
         self.lbfgs = self
             .lbfgs
             .with_cbfgs_alpha(alpha)

--- a/src/core/panoc/tests_f32.rs
+++ b/src/core/panoc/tests_f32.rs
@@ -6,7 +6,7 @@ use crate::{mocks, FunctionCallResult};
 const N_DIM: usize = 2;
 #[test]
 fn t_panoc_init() {
-    let radius = 0.2;
+    let radius = 0.2_f32;
     let ball = constraints::Ball2::new(None, radius);
     let problem = Problem::new(&ball, mocks::my_gradient, mocks::my_cost);
     let mut panoc_cache = PANOCCache::new(N_DIM, 1e-6, 5);
@@ -57,7 +57,7 @@ fn print_panoc_engine<GradientType, ConstraintType, CostType, T>(
 
 #[test]
 fn t_test_panoc_basic() {
-    let bounds = constraints::Ball2::new(None, 0.2);
+    let bounds = constraints::Ball2::new(None, 0.2_f32);
     let problem = Problem::new(&bounds, mocks::my_gradient, mocks::my_cost);
     let tolerance = 1e-9;
     let mut panoc_cache = PANOCCache::new(2, tolerance, 5);
@@ -80,12 +80,12 @@ fn t_test_panoc_basic() {
     }
     println!("final |fpr| = {}", panoc_engine.cache.norm_gamma_fpr);
     assert!(panoc_engine.cache.norm_gamma_fpr <= tolerance);
-    unit_test_utils::assert_nearly_equal_array(&u, &mocks::SOLUTION_A, 1e-6, 1e-8, "");
+    unit_test_utils::assert_nearly_equal_array(&u, &mocks::SOLUTION_A_F32, 1e-6, 1e-8, "");
 }
 
 #[test]
 fn t_test_panoc_hard() {
-    let radius: f64 = 0.05;
+    let radius: f32 = 0.05_f32;
     let bounds = constraints::Ball2::new(None, radius);
     let problem = Problem::new(
         &bounds,
@@ -94,11 +94,11 @@ fn t_test_panoc_hard() {
     );
     let n: usize = 3;
     let lbfgs_memory: usize = 10;
-    let tolerance_fpr: f64 = 1e-12;
+    let tolerance_fpr: f32 = 1e-12;
     let mut panoc_cache = PANOCCache::new(n, tolerance_fpr, lbfgs_memory);
     let mut panoc_engine = PANOCEngine::new(problem, &mut panoc_cache);
 
-    let mut u = [-20., 10., 0.2];
+    let mut u = [-20.0, 10., 0.2];
     panoc_engine.init(&mut u).unwrap();
 
     println!("L     = {}", panoc_engine.cache.lipschitz_constant);
@@ -115,19 +115,19 @@ fn t_test_panoc_hard() {
 
     println!("\nsol = {:?}", u);
     assert!(panoc_engine.cache.norm_gamma_fpr <= tolerance_fpr);
-    unit_test_utils::assert_nearly_equal_array(&u, &mocks::SOLUTION_HARD, 1e-6, 1e-8, "");
+    unit_test_utils::assert_nearly_equal_array(&u, &mocks::SOLUTION_HARD_F32, 1e-6, 1e-8, "");
 }
 
 #[test]
 fn t_test_panoc_rosenbrock() {
-    let tolerance = 1e-12;
+    let tolerance = 1e-12_f32;
     let a_param = 1.0;
     let b_param = 100.0;
-    let cost_gradient = |u: &[f64], grad: &mut [f64]| -> FunctionCallResult {
+    let cost_gradient = |u: &[f32], grad: &mut [f32]| -> FunctionCallResult {
         mocks::rosenbrock_grad(a_param, b_param, u, grad);
         Ok(())
     };
-    let cost_function = |u: &[f64], c: &mut f64| -> FunctionCallResult {
+    let cost_function = |u: &[f32], c: &mut f32| -> FunctionCallResult {
         *c = mocks::rosenbrock_cost(a_param, b_param, u);
         Ok(())
     };
@@ -147,18 +147,18 @@ fn t_test_panoc_rosenbrock() {
 
 #[test]
 fn t_zero_gamma_l() {
-    let tolerance = 1e-8;
+    let tolerance = 1e-8_f32;
     let mut panoc_cache = PANOCCache::new(1, tolerance, 5);
     let u = &mut [1e6];
 
     // Define the cost function and its gradient.
-    let df = |u: &[f64], grad: &mut [f64]| -> Result<(), SolverError> {
+    let df = |u: &[f32], grad: &mut [f32]| -> Result<(), SolverError> {
         grad[0] = u[0].signum();
 
         Ok(())
     };
 
-    let f = |u: &[f64], c: &mut f64| -> Result<(), SolverError> {
+    let f = |u: &[f32], c: &mut f32| -> Result<(), SolverError> {
         *c = u[0].abs();
         Ok(())
     };
@@ -180,13 +180,13 @@ fn t_zero_gamma_l() {
 
 #[test]
 fn t_zero_gamma_huber() {
-    let tolerance = 1e-8;
+    let tolerance = 1e-8_f32;
     let mut panoc_cache = PANOCCache::new(1, tolerance, 10);
     let u = &mut [1e6];
     let huber_delta = 1e-6;
 
     // Define the cost function and its gradient.
-    let df = |u: &[f64], grad: &mut [f64]| -> Result<(), SolverError> {
+    let df = |u: &[f32], grad: &mut [f32]| -> Result<(), SolverError> {
         let u_abs = u[0].abs();
         if u_abs >= huber_delta {
             grad[0] = huber_delta * u[0].signum();
@@ -196,7 +196,7 @@ fn t_zero_gamma_huber() {
         Ok(())
     };
 
-    let huber_norm = |u: &[f64], y: &mut f64| -> Result<(), SolverError> {
+    let huber_norm = |u: &[f32], y: &mut f32| -> Result<(), SolverError> {
         let u_abs = u[0].abs();
         if u_abs <= huber_delta {
             *y = 0.5 * u[0].powi(2);

--- a/src/core/problem.rs
+++ b/src/core/problem.rs
@@ -6,8 +6,8 @@
 //! Cost functions are user defined. They can either be defined in Rust or in
 //! C (and then invoked from Rust via an interface such as icasadi).
 //!
+use crate::core::OptFloat;
 use crate::{constraints, FunctionCallResult};
-
 /// Definition of an optimisation problem
 ///
 /// The definition of an optimisation problem involves:
@@ -15,11 +15,12 @@ use crate::{constraints, FunctionCallResult};
 /// - the cost function
 /// - the set of constraints, which is described by implementations of
 ///   [Constraint](../../panoc_rs/constraints/trait.Constraint.html)
-pub struct Problem<'a, GradientType, ConstraintType, CostType>
+pub struct Problem<'a, GradientType, ConstraintType, CostType, T>
 where
-    GradientType: Fn(&[f64], &mut [f64]) -> FunctionCallResult,
-    CostType: Fn(&[f64], &mut f64) -> FunctionCallResult,
-    ConstraintType: constraints::Constraint,
+    GradientType: Fn(&[T], &mut [T]) -> FunctionCallResult,
+    CostType: Fn(&[T], &mut T) -> FunctionCallResult,
+    ConstraintType: constraints::Constraint<T>,
+    T: OptFloat,
 {
     /// constraints
     pub(crate) constraints: &'a ConstraintType,
@@ -27,13 +28,17 @@ where
     pub(crate) gradf: GradientType,
     /// cost function
     pub(crate) cost: CostType,
+    /// phantom data for float type
+    _phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, GradientType, ConstraintType, CostType> Problem<'a, GradientType, ConstraintType, CostType>
+impl<'a, GradientType, ConstraintType, CostType, T>
+    Problem<'a, GradientType, ConstraintType, CostType, T>
 where
-    GradientType: Fn(&[f64], &mut [f64]) -> FunctionCallResult,
-    CostType: Fn(&[f64], &mut f64) -> FunctionCallResult,
-    ConstraintType: constraints::Constraint,
+    GradientType: Fn(&[T], &mut [T]) -> FunctionCallResult,
+    CostType: Fn(&[T], &mut T) -> FunctionCallResult,
+    ConstraintType: constraints::Constraint<T>,
+    T: OptFloat,
 {
     /// Construct a new instance of an optimisation problem
     ///
@@ -50,11 +55,12 @@ where
         constraints: &'a ConstraintType,
         cost_gradient: GradientType,
         cost: CostType,
-    ) -> Problem<'a, GradientType, ConstraintType, CostType> {
+    ) -> Problem<'a, GradientType, ConstraintType, CostType, T> {
         Problem {
             constraints,
             gradf: cost_gradient,
             cost,
+            _phantom: std::marker::PhantomData,
         }
     }
 }

--- a/src/core/solver_status.rs
+++ b/src/core/solver_status.rs
@@ -1,16 +1,19 @@
 //! Status of the result of a solver (number of iterations, etc)
 //!
 //!
-use crate::core::ExitStatus;
 use std::time;
 
+use crate::core::{ExitStatus, OptFloat};
 /// Solver status
 ///
 /// This structure contais information about the solver status. Instances of
 /// `SolverStatus` are returned by optimizers.
 ///
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub struct SolverStatus {
+pub struct SolverStatus<T>
+where
+    T: OptFloat,
+{
     /// exit status of the algorithm
     exit_status: ExitStatus,
     /// number of iterations for convergence
@@ -18,12 +21,15 @@ pub struct SolverStatus {
     /// time it took to solve
     solve_time: time::Duration,
     /// norm of the fixed-point residual (FPR)
-    fpr_norm: f64,
+    fpr_norm: T,
     /// cost value at the candidate solution
-    cost_value: f64,
+    cost_value: T,
 }
 
-impl SolverStatus {
+impl<T> SolverStatus<T>
+where
+    T: OptFloat,
+{
     /// Constructs a new instance of SolverStatus
     ///
     /// ## Arguments
@@ -39,9 +45,9 @@ impl SolverStatus {
         exit_status: ExitStatus,
         num_iter: usize,
         solve_time: time::Duration,
-        fpr_norm: f64,
-        cost_value: f64,
-    ) -> SolverStatus {
+        fpr_norm: T,
+        cost_value: T,
+    ) -> SolverStatus<T> {
         SolverStatus {
             exit_status,
             num_iter,
@@ -67,12 +73,12 @@ impl SolverStatus {
     }
 
     /// norm of the fixed point residual
-    pub fn norm_fpr(&self) -> f64 {
+    pub fn norm_fpr(&self) -> T {
         self.fpr_norm
     }
 
     /// value of the cost at the solution
-    pub fn cost_value(&self) -> f64 {
+    pub fn cost_value(&self) -> T {
         self.cost_value
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,14 +58,12 @@ pub mod core;
 pub mod lipschitz_estimator;
 pub mod matrix_operations;
 
-pub use crate::core::fbs;
-pub use crate::core::panoc;
-pub use crate::core::{AlgorithmEngine, Optimizer, Problem};
-
 /* Use Jemalloc if the feature `jem` is activated */
 #[cfg(not(target_env = "msvc"))]
 #[cfg(feature = "jem")]
 use jemallocator::Jemalloc;
+
+pub use crate::core::{fbs, panoc, AlgorithmEngine, OptFloat, Optimizer, Problem};
 
 #[cfg(not(target_env = "msvc"))]
 #[cfg(feature = "jem")]

--- a/src/matrix_operations.rs
+++ b/src/matrix_operations.rs
@@ -36,9 +36,10 @@
 //! ```
 //!
 
-use num::{Float, Zero};
 use std::iter::Sum;
 use std::ops::Mul;
+
+use num::{Float, Zero};
 
 /// Calculate the inner product of two vectors
 #[inline(always)]
@@ -74,10 +75,10 @@ where
 #[inline(always)]
 pub fn norm2_squared_diff<T>(a: &[T], b: &[T]) -> T
 where
-    T: Float + Sum<T> + Mul<T, Output = T> + std::ops::AddAssign,
+    T: Float + Sum<T> + Mul<T, Output = T>,
 {
     a.iter().zip(b.iter()).fold(T::zero(), |mut sum, (&x, &y)| {
-        sum += (x - y).powi(2);
+        sum = sum + (x - y).powi(2);
         sum
     })
 }

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -1,81 +1,105 @@
-use crate::{matrix_operations, SolverError};
+use crate::{matrix_operations, OptFloat, SolverError};
 
 pub const SOLUTION_A: [f64; 2] = [-0.148_959_718_255_77, 0.133_457_867_273_39];
+pub const SOLUTION_A_F32: [f32; 2] = [-0.148_959_7, 0.133_457_9];
+
 pub const SOLUTION_HARD: [f64; 3] = [
     -0.041_123_164_672_281,
     -0.028_440_417_469_206,
     0.000_167_276_757_790,
 ];
+pub const SOLUTION_HARD_F32: [f32; 3] = [-0.041_123_1, -0.028_440_52, 0.000_167_275_72];
 
-pub fn lipschitz_mock(u: &[f64], g: &mut [f64]) -> Result<(), SolverError> {
-    g[0] = 3.0 * u[0];
-    g[1] = 2.0 * u[1];
-    g[2] = 4.5;
+pub fn lipschitz_mock<T: OptFloat>(u: &[T], g: &mut [T]) -> Result<(), SolverError> {
+    g[0] = T::from(3.0).unwrap() * u[0];
+    g[1] = T::from(2.0).unwrap() * u[1];
+    g[2] = T::from(4.5).unwrap();
     Ok(())
 }
 
-pub fn void_parameteric_cost(_u: &[f64], _p: &[f64], _cost: &mut f64) -> Result<(), SolverError> {
-    Ok(())
-}
-
-pub fn void_parameteric_gradient(
-    _u: &[f64],
-    _p: &[f64],
-    _grad: &mut [f64],
+pub fn void_parameteric_cost<T: OptFloat>(
+    _u: &[T],
+    _p: &[T],
+    _cost: &mut T,
 ) -> Result<(), SolverError> {
     Ok(())
 }
 
-pub fn void_mapping(_u: &[f64], _result: &mut [f64]) -> Result<(), SolverError> {
+pub fn void_parameteric_gradient<T: OptFloat>(
+    _u: &[T],
+    _p: &[T],
+    _grad: &mut [T],
+) -> Result<(), SolverError> {
     Ok(())
 }
 
-pub fn void_cost(_u: &[f64], _cost: &mut f64) -> Result<(), SolverError> {
+pub fn void_mapping<T: OptFloat>(_u: &[T], _result: &mut [T]) -> Result<(), SolverError> {
     Ok(())
 }
 
-pub fn void_gradient(_u: &[f64], _grad: &mut [f64]) -> Result<(), SolverError> {
+pub fn void_cost<T: OptFloat>(_u: &[T], _cost: &mut T) -> Result<(), SolverError> {
     Ok(())
 }
 
-pub fn my_cost(u: &[f64], cost: &mut f64) -> Result<(), SolverError> {
-    *cost = 0.5 * (u[0].powi(2) + 2. * u[1].powi(2) + 2.0 * u[0] * u[1]) + u[0] - u[1] + 3.0;
+pub fn void_gradient<T: OptFloat>(_u: &[T], _grad: &mut [T]) -> Result<(), SolverError> {
     Ok(())
 }
 
-pub fn my_gradient(u: &[f64], grad: &mut [f64]) -> Result<(), SolverError> {
-    grad[0] = u[0] + u[1] + 1.0;
-    grad[1] = u[0] + 2. * u[1] - 1.0;
+pub fn my_cost<T: OptFloat>(u: &[T], cost: &mut T) -> Result<(), SolverError> {
+    *cost = T::from(0.5).unwrap()
+        * (u[0].powi(2)
+            + T::from(2.0).unwrap() * u[1].powi(2)
+            + T::from(2.0).unwrap() * u[0] * u[1])
+        + u[0]
+        - u[1]
+        + T::from(3.0).unwrap();
     Ok(())
 }
 
-pub fn rosenbrock_cost(a: f64, b: f64, u: &[f64]) -> f64 {
+pub fn my_gradient<T: OptFloat>(u: &[T], grad: &mut [T]) -> Result<(), SolverError> {
+    grad[0] = u[0] + u[1] + T::one();
+    grad[1] = u[0] + T::from(2.0).unwrap() * u[1] - T::one();
+    Ok(())
+}
+
+pub fn rosenbrock_cost<T: OptFloat>(a: T, b: T, u: &[T]) -> T {
     (a - u[0]).powi(2) + b * (u[1] - u[0].powi(2)).powi(2)
 }
 
-pub fn rosenbrock_grad(a: f64, b: f64, u: &[f64], grad: &mut [f64]) {
-    grad[0] = 2.0 * u[0] - 2.0 * a - 4.0 * b * u[0] * (-u[0].powi(2) + u[1]);
-    grad[1] = b * (-2.0 * u[0].powi(2) + 2.0 * u[1]);
+pub fn rosenbrock_grad<T: OptFloat>(a: T, b: T, u: &[T], grad: &mut [T]) {
+    grad[0] = T::from(2.0).unwrap() * u[0]
+        - T::from(2.0).unwrap() * a
+        - T::from(4.0).unwrap() * b * u[0] * (-u[0].powi(2) + u[1]);
+    grad[1] = b * (T::from(-2.0).unwrap() * u[0].powi(2) + T::from(2.0).unwrap() * u[1]);
 }
 
-pub fn hard_quadratic_cost(u: &[f64], cost: &mut f64) -> Result<(), SolverError> {
-    *cost = (4. * u[0].powi(2)) / 2.
-        + 5.5 * u[1].powi(2)
-        + 500.5 * u[2].powi(2)
-        + 5. * u[0] * u[1]
-        + 25. * u[0] * u[2]
-        + 5. * u[1] * u[2]
+pub fn hard_quadratic_cost<T: OptFloat>(u: &[T], cost: &mut T) -> Result<(), SolverError> {
+    *cost = T::from(4.0).unwrap() * u[0].powi(2) / T::from(2.0).unwrap()
+        + T::from(5.5).unwrap() * u[1].powi(2)
+        + T::from(500.5).unwrap() * u[2].powi(2)
+        + T::from(5.0).unwrap() * u[0] * u[1]
+        + T::from(25.0).unwrap() * u[0] * u[2]
+        + T::from(5.0).unwrap() * u[1] * u[2]
         + u[0]
         + u[1]
         + u[2];
     Ok(())
 }
 
-pub fn hard_quadratic_gradient(u: &[f64], grad: &mut [f64]) -> Result<(), SolverError> {
+pub fn hard_quadratic_gradient<T: OptFloat>(u: &[T], grad: &mut [T]) -> Result<(), SolverError> {
     // norm(Hessian) = 1000.653 (Lipschitz gradient)
-    grad[0] = 4. * u[0] + 5. * u[1] + 25. * u[2] + 1.;
-    grad[1] = 5. * u[0] + 11. * u[1] + 5. * u[2] + 1.;
-    grad[2] = 25. * u[0] + 5. * u[1] + 1001. * u[2] + 1.;
+    grad[0] = T::from(4.0).unwrap() * u[0]
+        + T::from(5.0).unwrap() * u[1]
+        + T::from(25.0).unwrap() * u[2]
+        + T::one();
+    grad[1] = T::from(5.0).unwrap() * u[0]
+        + T::from(11.0).unwrap() * u[1]
+        + T::from(5.0).unwrap() * u[2]
+        + T::one();
+    grad[2] = T::from(25.0).unwrap() * u[0]
+        + T::from(5.0).unwrap() * u[1]
+        + T::from(1001.0).unwrap() * u[2]
+        + T::one();
     Ok(())
 }
 
@@ -85,28 +109,33 @@ pub fn hard_quadratic_gradient(u: &[f64], grad: &mut [f64]) -> Result<(), Solver
 ///
 /// where `m` is the length of `xi`. It is assumed that the length of
 /// `u` is larger than the length of `xi`
-pub fn psi_cost_dummy(u: &[f64], xi: &[f64], cost: &mut f64) -> Result<(), SolverError> {
+pub fn psi_cost_dummy<T: OptFloat>(u: &[T], xi: &[T], cost: &mut T) -> Result<(), SolverError> {
     let u_len = u.len();
     let xi_len = xi.len();
     assert!(u_len > xi_len);
-    let sum_u = u.iter().fold(0.0, |mut sum, ui| {
-        sum += ui;
+    let sum_u = u.iter().fold(T::zero(), |mut sum, ui| {
+        sum = sum + *ui;
         sum
     });
     // psi_cost = 0.5*SUM(ui^2) + xi[0] * sum_u
-    *cost =
-        0.5 * u.iter().fold(0.0, |mut sum_of_squares, ui| {
-            sum_of_squares += ui.powi(2);
+    *cost = T::from(0.5).unwrap()
+        * u.iter().fold(T::zero(), |mut sum_of_squares, ui| {
+            sum_of_squares = sum_of_squares + ui.powi(2);
             sum_of_squares
-        }) + xi[0] * sum_u;
+        })
+        + xi[0] * sum_u;
     // psi_cost += xi[1..m]'*u[0..m-1]
     let m = std::cmp::min(u_len, xi_len - 1);
-    *cost += matrix_operations::inner_product(&u[..m], &xi[1..=m]);
+    *cost = *cost + matrix_operations::inner_product(&u[..m], &xi[1..=m]);
     Ok(())
 }
 
 /// Gradient of `psi_cost`
-pub fn psi_gradient_dummy(u: &[f64], xi: &[f64], grad: &mut [f64]) -> Result<(), SolverError> {
+pub fn psi_gradient_dummy<T: OptFloat>(
+    u: &[T],
+    xi: &[T],
+    grad: &mut [T],
+) -> Result<(), SolverError> {
     let u_len = u.len();
     let xi_len = xi.len();
     assert!(
@@ -115,11 +144,11 @@ pub fn psi_gradient_dummy(u: &[f64], xi: &[f64], grad: &mut [f64]) -> Result<(),
     );
     assert!(u_len == grad.len(), "u and grad must have equal lengths");
     grad.copy_from_slice(u);
-    grad.iter_mut().for_each(|grad_i| *grad_i += xi[0]);
+    grad.iter_mut().for_each(|grad_i| *grad_i = *grad_i + xi[0]);
     xi[1..]
         .iter()
         .zip(grad.iter_mut())
-        .for_each(|(xi_i, grad_i)| *grad_i += xi_i);
+        .for_each(|(xi_i, grad_i)| *grad_i = *grad_i + *xi_i);
     Ok(())
 }
 
@@ -132,11 +161,11 @@ pub fn psi_gradient_dummy(u: &[f64], xi: &[f64], grad: &mut [f64]) -> Result<(),
 ///
 /// It is `F1: R^3 --> R^2`
 ///
-pub fn mapping_f1_affine(u: &[f64], f1u: &mut [f64]) -> Result<(), SolverError> {
+pub fn mapping_f1_affine<T: OptFloat>(u: &[T], f1u: &mut [T]) -> Result<(), SolverError> {
     assert!(u.len() == 3, "the length of u must be equal to 3");
     assert!(f1u.len() == 2, "the length of F1(u) must be equal to 2");
-    f1u[0] = 2.0 * u[0] + u[2] - 1.0;
-    f1u[1] = u[0] + 3.0 * u[1];
+    f1u[0] = T::from(2.0).unwrap() * u[0] + u[2] - T::one();
+    f1u[1] = u[0] + T::from(3.0).unwrap() * u[1];
     Ok(())
 }
 
@@ -151,15 +180,15 @@ pub fn mapping_f1_affine(u: &[f64], f1u: &mut [f64]) -> Result<(), SolverError> 
 ///              d1        ]
 /// ```
 ///  
-pub fn mapping_f1_affine_jacobian_product(
-    _u: &[f64],
-    d: &[f64],
-    res: &mut [f64],
+pub fn mapping_f1_affine_jacobian_product<T: OptFloat>(
+    _u: &[T],
+    d: &[T],
+    res: &mut [T],
 ) -> Result<(), SolverError> {
     assert!(d.len() == 2, "the length of d must be equal to 3");
     assert!(res.len() == 3, "the length of res must be equal to 3");
-    res[0] = 2.0 * d[0] + d[1];
-    res[1] = 3.0 * d[1];
+    res[0] = T::from(2.0).unwrap() * d[0] + d[1];
+    res[1] = T::from(3.0).unwrap() * d[1];
     res[2] = d[0];
     Ok(())
 }
@@ -169,15 +198,15 @@ pub fn mapping_f1_affine_jacobian_product(
 /// ```
 /// f0(u) = 0.5*u'*u + 1'*u
 /// ```
-pub fn f0(u: &[f64], cost: &mut f64) -> Result<(), SolverError> {
-    *cost = 0.5 * matrix_operations::norm2_squared(u) + matrix_operations::sum(u);
+pub fn f0<T: OptFloat>(u: &[T], cost: &mut T) -> Result<(), SolverError> {
+    *cost = T::from(0.5).unwrap() * matrix_operations::norm2_squared(u) + matrix_operations::sum(u);
     Ok(())
 }
 
-pub fn d_f0(u: &[f64], grad: &mut [f64]) -> Result<(), SolverError> {
+pub fn d_f0<T: OptFloat>(u: &[T], grad: &mut [T]) -> Result<(), SolverError> {
     grad.iter_mut()
         .zip(u.iter())
-        .for_each(|(grad_i, u_i)| *grad_i = u_i + 1.0);
+        .for_each(|(grad_i, u_i)| *grad_i = *u_i + T::one());
     Ok(())
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,9 +1,12 @@
-use crate::{constraints::*, core::fbs::*, core::*};
 use std::num::NonZeroUsize;
+
+use crate::constraints::*;
+use crate::core::fbs::*;
+use crate::core::*;
 
 #[test]
 fn t_access() {
-    let radius = 0.2;
+    let radius = 0.2_f64;
     let box_constraints = Ball2::new(None, radius);
     let problem = Problem::new(
         &box_constraints,
@@ -23,4 +26,28 @@ fn t_access() {
     assert!(status.norm_fpr() < tolerance);
     assert!((-0.14896 - u[0]).abs() < 1e-4);
     assert!((0.13346 - u[1]).abs() < 1e-4);
+}
+
+#[test]
+fn t_access_f32() {
+    let radius = 0.2f32;
+    let box_constraints = Ball2::new(None, radius);
+    let problem = Problem::new(
+        &box_constraints,
+        super::mocks::my_gradient,
+        super::mocks::my_cost,
+    );
+    let gamma = 0.1f32;
+    let tolerance = 1e-6f32;
+
+    let mut fbs_cache = FBSCache::new(NonZeroUsize::new(2).unwrap(), gamma, tolerance);
+    let mut u = [0.0f32; 2];
+    let mut optimizer = FBSOptimizer::new(problem, &mut fbs_cache);
+
+    let status = optimizer.solve(&mut u).unwrap();
+
+    assert!(status.has_converged());
+    assert!(status.norm_fpr() < tolerance);
+    assert!((-0.14896f32 - u[0]).abs() < 1e-4f32);
+    assert!((0.13346f32 - u[1]).abs() < 1e-4f32);
 }


### PR DESCRIPTION
## Main Changes

I wanted to try the core crate out on a microcontroller that just has hard-floats for f32, so I hacked this together. I'm only using PANOC without constraints, so I'm not sure if anything really works that well outside of what I used. Perhaps the complexity is somewhat inevitable to support f32/f64, but it's annoying how much extra boilerplate is added with this. Nonetheless, it could be a good basis for adding f32 support here.

- Make a OptFloat trait
- Provide PANOC constants implemented for f32 and f64
- Use somewhat arbitrary values for f32 PANOC constants, unclear how good these are. These should be looked at.
- Add some tests for f32 (some of which are failing!)

## Associated Issues

- Related to https://github.com/alphaville/optimization-engine/issues/372

## TODOs

- [ ] Documentation
- [ ] All tests must pass
- [ ] Update `CHANGELOG`(s)
- [ ] Update webpage documentation
- [ ] Bump versions (in `CHANGELOG`, `Cargo.toml` and `VERSION`)
- [ ] Use non-forked version of lbfgs-rs
